### PR TITLE
Publish a docker image on latest develop & release_candidate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ workflows:
             - docker/test_image
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - develop
+                - release_candidate
             tags:
               only: /v.*/


### PR DESCRIPTION
For dev & staging environment, infra development, continuous
deployment, we may need an image to deploy.