### PR TITLE
Hotfix/parse long number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,5 @@ workflows:
                 - master
                 - develop
                 - release_candidate
-                - develop_eth_erc20
             tags:
               only: /v.*/

--- a/src/main/scala/co/ledger/wallet/daemon/models/coins/Ethereum.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/coins/Ethereum.scala
@@ -65,7 +65,7 @@ object EthereumTransactionView {
         val data = HexUtils.valueOf(byteArray).toLowerCase()
         data match {
           case erc20(receiver, amount) =>
-            Right(ERC20(receiver, amount.toLong))
+            Right(ERC20(receiver, BigDecimal.apply(amount).toLongExact))
           case _ => Left(s"bad erc20 data format: $data")
         }
       } else Left("bad erc20 data size")


### PR DESCRIPTION
Ran into this error while testing the latest branch with ETH:

```2019-01-03 09:58:08,544 scala-execution-context-global-71 TraceId=e611e9f29b3a8091 CorrelationId=428ce2d2-27a8-4e5b-ba03-ef0f97199af2 [INFO] AccountsController : GET account operations Request("GET /pools/ledger1/wallets/ethereum_ropsten/accounts/0/operations?next=636268a6-6e8d-4b90-8f53-ec1ce7808f65&full_op=1", from /127.0.0.1:50930), Parameters(user: 7)
2019-01-03 09:58:08,544 scala-execution-context-global-71 TraceId=e611e9f29b3a8091 CorrelationId=428ce2d2-27a8-4e5b-ba03-ef0f97199af2 [INFO] AccountsService : Retrieve next batch operation
2019-01-03 09:58:08,572 scala-execution-context-global-73 TraceId=e611e9f29b3a8091 CorrelationId=428ce2d2-27a8-4e5b-ba03-ef0f97199af2 [ERROR] ThrowableExceptionMapper : Unhandled Exception
java.lang.NumberFormatException: For input string: "00000000000000000000000000000000000000000000000000000000000003e8"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.parseLong(Long.java:631)
	at scala.collection.immutable.StringLike.toLong(StringLike.scala:306)
	at scala.collection.immutable.StringLike.toLong$(StringLike.scala:306)
	at scala.collection.immutable.StringOps.toLong(StringOps.scala:29)
	at co.ledger.wallet.daemon.models.coins.EthereumTransactionView$ERC20$.from(Ethereum.scala:68)
	at co.ledger.wallet.daemon.models.coins.EthereumTransactionView$.apply(Ethereum.scala:51)
	at co.ledger.wallet.daemon.models.Operations$.getTransactionView(Operations.scala:67)
	at co.ledger.wallet.daemon.models.Operations$.$anonfun$getView$2(Operations.scala:51)
	at scala.util.Success.$anonfun$map$1(Try.scala:251)
	at scala.util.Success.map(Try.scala:209)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:287)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at co.ledger.wallet.daemon.async.MDCPropagatingExecutionContext$$anon$1.$anonfun$execute$1(MDCPropagatingExecutionContext.scala:30)
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:140)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.pollAndExecAll(ForkJoinPool.java:1021)
	at java.util.concurrent.ForkJoinPool$WorkQueue.execLocalTasks(ForkJoinPool.java:1046)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1058)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
2019-01-03 09:58:08,575 scala-execution-context-global-73 TraceId=e611e9f29b3a8091 CorrelationId=428ce2d2-27a8-4e5b-ba03-ef0f97199af2 [WARN] ResponseBuilder : Request Failure: Internal/Unhandled/java.lang.NumberFormatException
```

This fix seems to properly parse the amount in the formats we supply. Don't know if we should use this in other locations @luchenyuxx ?