### PR TITLE
Use contract address if available to compute gas limit

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -191,7 +191,7 @@ object Account extends Logging {
           }
           gasLimit <- ti.gasLimit match {
             case Some(amount) => Future.successful(amount)
-            case None => ClientFactory.apiClient.getGasLimit(c.getName, ti.recipient)
+            case None => ClientFactory.apiClient.getGasLimit(c.getName, ti.contract.getOrElse(ti.recipient))
           }
           v <- ti.contract match {
             case Some(contract) =>


### PR DESCRIPTION
In the case of erc20 tokens, the gas limit should be estimated using the contract address as the recipient.
For vanilla eth, we keep the actual recipient to do the estimation.