### PR TITLE
Update lib core to produce eip55 addresses and handle lowercase bug

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
@@ -38,7 +38,7 @@ class ApiClient(implicit val ec: ExecutionContext) {
 
   def getGasLimit(currencyName: String, recipient: String): Future[BigInt] = {
     val (host, service) = services.getOrElse(currencyName, services("default"))
-    val request = Request(Method.Get, s"/blockchain/v3/addresses/$recipient/estimate-gas-limit")
+    val request = Request(Method.Get, s"/blockchain/v3/addresses/${recipient.toLowerCase}/estimate-gas-limit")
       .host(host)
     service(request).map { response =>
       mapper.parse[GasLimit](response).limit


### PR DESCRIPTION
New lib core version which stores eip55 formatted contract addresses
+ hotfix when calling explorer to get gas limit