### PR TITLE
Expect string amounts and parse them when creating transactions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ workflows:
               only:
                 - master
                 - develop
+                - develop-drop2
                 - release_candidate
             tags:
               only: /v.*/

--- a/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
@@ -109,25 +109,31 @@ object TransactionsController {
   }
 
   case class CreateETHTransactionRequest(recipient: String,
-                                         amount: BigInt,
-                                         gas_limit: Option[BigInt],
-                                         gas_price: Option[BigInt],
+                                         amount: String,
+                                         gas_limit: Option[String],
+                                         gas_price: Option[String],
                                          contract: Option[String]
                                         ) extends CreateTransactionRequest {
-    override def transactionInfo: TransactionInfo = ETHTransactionInfo(recipient, amount, gas_limit, gas_price, contract)
+    def amountValue: BigInt = BigInt(amount)
+    def gasLimitValue: Option[BigInt] = gas_limit.map(BigInt(_))
+    def gasPriceValue: Option[BigInt] = gas_price.map(BigInt(_))
+
+    override def transactionInfo: TransactionInfo = ETHTransactionInfo(recipient, amountValue, gasLimitValue, gasPriceValue, contract)
   }
 
   case class CreateBTCTransactionRequest(recipient: String,
-                                         fees_per_byte: Option[BigInt],
+                                         fees_per_byte: Option[String],
                                          fees_level: Option[String],
-                                         amount: BigInt,
+                                         amount: String,
                                          exclude_utxos: Option[Map[String, Int]],
                                         ) extends CreateTransactionRequest {
+    def amountValue: BigInt = BigInt(amount)
+    def feesPerByteValue: Option[BigInt] = fees_per_byte.map(BigInt(_))
 
-    def transactionInfo: BTCTransactionInfo = BTCTransactionInfo(recipient, fees_per_byte, fees_level, amount, exclude_utxos.getOrElse(Map[String, Int]()))
+    def transactionInfo: BTCTransactionInfo = BTCTransactionInfo(recipient, feesPerByteValue, fees_level, amountValue, exclude_utxos.getOrElse(Map[String, Int]()))
 
     @MethodValidation
-    def validateFees: ValidationResult = CommonMethodValidations.validateFees(fees_per_byte, fees_level)
+    def validateFees: ValidationResult = CommonMethodValidations.validateFees(feesPerByteValue, fees_level)
   }
 
   trait TransactionInfo

--- a/src/main/scala/co/ledger/wallet/daemon/models/Operations.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Operations.scala
@@ -8,7 +8,6 @@ import co.ledger.wallet.daemon.models.Wallet.RichCoreWallet
 import co.ledger.wallet.daemon.models.coins.Coin.TransactionView
 import co.ledger.wallet.daemon.models.coins.{Bitcoin, EthereumTransactionView}
 import com.fasterxml.jackson.annotation.JsonProperty
-import co.ledger.wallet.daemon.utils.Utils.RichBigInt
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -44,8 +43,8 @@ object Operations {
       operation.getDate,
       Option(height),
       operation.getOperationType,
-      operation.getAmount.toBigInt.asScala,
-      operation.getFees.toBigInt.asScala,
+      operation.getAmount.toString,
+      operation.getFees.toString,
       wallet.getName,
       account.getIndex,
       operation.getSenders.asScala.toList,
@@ -83,8 +82,8 @@ object Operations {
                             @JsonProperty("time") time: Date,
                             @JsonProperty("block_height") blockHeight: Option[Long],
                             @JsonProperty("type") opType: core.OperationType,
-                            @JsonProperty("amount") amount: BigInt,
-                            @JsonProperty("fees") fees: BigInt,
+                            @JsonProperty("amount") amount: String,
+                            @JsonProperty("fees") fees: String,
                             @JsonProperty("wallet_name") walletName: String,
                             @JsonProperty("account_index") accountIndex: Int,
                             @JsonProperty("senders") senders: Seq[String],

--- a/src/main/scala/co/ledger/wallet/daemon/models/coins/Bitcoin.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/coins/Bitcoin.scala
@@ -8,7 +8,6 @@ import co.ledger.wallet.daemon.async.MDCPropagatingExecutionContext
 import co.ledger.wallet.daemon.models.coins.Coin._
 import co.ledger.wallet.daemon.utils.HexUtils
 import com.fasterxml.jackson.annotation.JsonProperty
-import co.ledger.wallet.daemon.utils.Utils.RichBigInt
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +32,7 @@ object Bitcoin {
   def newTransactionView(from: core.BitcoinLikeTransaction): TransactionView = {
     BitcoinTransactionView(
       Option(from.getBlock).map (newBlockView),
-      Option(from.getFees).map (fees => fees.toBigInt.asScala),
+      Option(from.getFees).map (fees => fees.toString),
       from.getHash,
       from.getTime,
       from.getInputs.asScala.map(newInputView),
@@ -46,8 +45,8 @@ object Bitcoin {
     Future.sequence(from.getInputs.asScala.map(newUnsignedInputView)).map { unsignedInputs =>
       UnsignedBitcoinTransactionView(
         newEstimatedSizeView(from.getEstimatedSize),
-        from.getFees.toBigInt.asScala,
-        feesPerByte,
+        from.getFees.toString,
+        feesPerByte.toString,
         unsignedInputs,
         from.getLockTime,
         from.getOutputs.asScala.map(newUnsignedOutputView),
@@ -59,7 +58,7 @@ object Bitcoin {
   private def newUnsignedOutputView(from: core.BitcoinLikeOutput): UnsignedBitcoinOutputView = {
     UnsignedBitcoinOutputView(
       from.getAddress,
-      from.getValue.toBigInt.asScala,
+      from.getValue.toString,
       HexUtils.valueOf(from.getScript),
       Option(from.getDerivationPath).map(_.toString)
     )
@@ -81,7 +80,7 @@ object Bitcoin {
       } yield (path.toString, HexUtils.valueOf(pubKey))
       UnsignedBitcoinInputView(
         from.getAddress,
-        from.getValue.toBigInt.asScala,
+        from.getValue.toString,
         from.getPreviousTxHash,
         HexUtils.valueOf(previousTx),
         from.getPreviousOutputIndex,
@@ -91,11 +90,11 @@ object Bitcoin {
 
   private def newInputView(from: core.BitcoinLikeInput): InputView = {
     val previousIndex: Int = from.getPreviousOutputIndex
-    BitcoinInputView(from.getAddress, from.getValue.toBigInt.asScala, Option(from.getCoinbase), Option(from.getPreviousTxHash), Option(previousIndex))
+    BitcoinInputView(from.getAddress, from.getValue.toString, Option(from.getCoinbase), Option(from.getPreviousTxHash), Option(previousIndex))
   }
 
   private def newOutputView(from: core.BitcoinLikeOutput): OutputView = {
-    BitcoinOutputView(from.getAddress, from.getTransactionHash, from.getOutputIndex, from.getValue.toBigInt.asScala, HexUtils.valueOf(from.getScript))
+    BitcoinOutputView(from.getAddress, from.getTransactionHash, from.getOutputIndex, from.getValue.toString, HexUtils.valueOf(from.getScript))
   }
 }
 
@@ -112,7 +111,7 @@ case class BitcoinNetworkParamsView(
 
 case class BitcoinTransactionView(
                                    @JsonProperty("block") block: Option[BlockView],
-                                   @JsonProperty("fees") fees: Option[BigInt],
+                                   @JsonProperty("fees") fees: Option[String],
                                    @JsonProperty("hash") hash: String,
                                    @JsonProperty("time") time: Date,
                                    @JsonProperty("inputs") inputs: Seq[InputView],
@@ -122,7 +121,7 @@ case class BitcoinTransactionView(
 
 case class BitcoinInputView(
                            @JsonProperty("address") address: String,
-                           @JsonProperty("value") value: BigInt,
+                           @JsonProperty("value") value: String,
                            @JsonProperty("coinbase") coinbase: Option[String],
                            @JsonProperty("previous_transaction_hash") previousTxHash: Option[String],
                            @JsonProperty("previous_output_index") previousOutputIndex: Option[Int]
@@ -132,13 +131,13 @@ case class BitcoinOutputView(
                             @JsonProperty("address") address: String,
                             @JsonProperty("transaction_hash") txHash: String,
                             @JsonProperty("output_index") outputIndex: Int,
-                            @JsonProperty("value") value: BigInt,
+                            @JsonProperty("value") value: String,
                             @JsonProperty("script") script: String
                             ) extends OutputView
 
 case class UnsignedBitcoinInputView(
                                    @JsonProperty("address") address: String,
-                                   @JsonProperty("value") value: BigInt,
+                                   @JsonProperty("value") value: String,
                                    @JsonProperty("previous_transaction_hash") previousTxHash: String,
                                    @JsonProperty("previous_transaction_raw") previousTx: String,
                                    @JsonProperty("previous_output_index") previousOutputIndex: Int,
@@ -147,15 +146,15 @@ case class UnsignedBitcoinInputView(
 
 case class UnsignedBitcoinOutputView(
                                     @JsonProperty("address") address: String,
-                                    @JsonProperty("value") value: BigInt,
+                                    @JsonProperty("value") value: String,
                                     @JsonProperty("script") script: String,
                                     @JsonProperty("derivation_path") derivationPath: Option[String]
                                     ) extends OutputView
 
 case class UnsignedBitcoinTransactionView(
                             @JsonProperty("estimated_size") estimatedSize: EstimatedSizeView,
-                            @JsonProperty("fees") fees: BigInt,
-                            @JsonProperty("fees_per_byte") feesPerByte: BigInt,
+                            @JsonProperty("fees") fees: String,
+                            @JsonProperty("fees_per_byte") feesPerByte: String,
                             @JsonProperty("inputs") inputs: Seq[UnsignedBitcoinInputView],
                             @JsonProperty("lock_time") lockTime: Long,
                             @JsonProperty("outputs") outputs: Seq[UnsignedBitcoinOutputView],

--- a/src/main/scala/co/ledger/wallet/daemon/models/coins/Ethereum.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/coins/Ethereum.scala
@@ -33,10 +33,10 @@ case class EthereumTransactionView(
                                     @JsonProperty("hash") hash: String,
                                     @JsonProperty("receiver") receiver: String,
                                     @JsonProperty("sender") sender: String,
-                                    @JsonProperty("value") value: scala.BigInt,
+                                    @JsonProperty("value") value: String,
                                     @JsonProperty("erc20") erc20: Option[EthereumTransactionView.ERC20],
-                                    @JsonProperty("gas_price") gasPrice: scala.BigInt,
-                                    @JsonProperty("gas_limit") gasLimit: scala.BigInt,
+                                    @JsonProperty("gas_price") gasPrice: String,
+                                    @JsonProperty("gas_limit") gasLimit: String,
                                     @JsonProperty("date") date: Date
                                   ) extends TransactionView
 
@@ -47,10 +47,10 @@ object EthereumTransactionView {
       tx.getHash,
       tx.getReceiver.toEIP55,
       tx.getSender.toEIP55,
-      tx.getValue.toBigInt.asScala,
+      tx.getValue.toString,
       ERC20.from(tx.getData).toOption,
-      tx.getGasPrice.toBigInt.asScala,
-      tx.getGasLimit.toBigInt.asScala,
+      tx.getGasPrice.toString,
+      tx.getGasLimit.toString,
       tx.getDate,
     )
   }
@@ -77,10 +77,10 @@ object EthereumTransactionView {
 case class UnsignedEthereumTransactionView(
                                             @JsonProperty("hash") hash: String,
                                             @JsonProperty("receiver") receiver: String,
-                                            @JsonProperty("value") value: scala.BigInt,
-                                            @JsonProperty("gas_price") gasPrice: scala.BigInt,
-                                            @JsonProperty("gas_limit") gasLimit: scala.BigInt,
-                                            @JsonProperty("fees") fees: scala.BigInt,
+                                            @JsonProperty("value") value: String,
+                                            @JsonProperty("gas_price") gasPrice: String,
+                                            @JsonProperty("gas_limit") gasLimit: String,
+                                            @JsonProperty("fees") fees: String,
                                             @JsonProperty("raw_transaction") rawTransaction: String
                                           ) extends TransactionView
 
@@ -89,10 +89,10 @@ object UnsignedEthereumTransactionView {
     UnsignedEthereumTransactionView(
       tx.getHash,
       tx.getReceiver.toEIP55,
-      tx.getValue.toBigInt.asScala,
-      tx.getGasPrice.toBigInt.asScala,
-      tx.getGasLimit.toBigInt.asScala,
-      tx.getGasPrice.toBigInt.asScala * tx.getGasLimit.toBigInt.asScala,
+      tx.getValue.toString,
+      tx.getGasPrice.toString,
+      tx.getGasLimit.toString,
+      (tx.getGasPrice.toBigInt.asScala * tx.getGasLimit.toBigInt.asScala).toString,
       HexUtils.valueOf(tx.serialize())
     )
   }


### PR DESCRIPTION
Update all the interfaces to send/expect every monetary amount as a string and ensure we don't lose precision in the communication.