### PR TITLE
Increase the time of token validity

### DIFF
--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -26,7 +26,7 @@ h2mem1 = {
 }
 
 authentication = {
-  token_duration_in_seconds = 30
+  token_duration_in_seconds = 3600
 }
 
 realtimeobservation = true

--- a/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 object DaemonConfiguration {
   private val config = ConfigFactory.load()
   private val PERMISSION_CREATE_USER: Int = 0x01
-  private val DEFAULT_AUTH_TOKEN_DURATION: Int = 30000 // 30 seconds
+  private val DEFAULT_AUTH_TOKEN_DURATION: Int = 3600 * 1000 // 30 seconds
   private val DEFAULT_SYNC_INTERVAL: Int = 24 // 24 hours
   private val DEFAULT_SYNC_INITIAL_DELAY: Int = 300 // 5 minutes
 


### PR DESCRIPTION
This hotfix was done on master during the latest release and never applied on dev.
https://github.com/LedgerHQ/ledger-wallet-daemon/pull/95

It extends the validity time of the auth tokens sent by the gate. A more in-depth work is required to remove this auth as much as possible.