### PR TITLE
Skip unsupported currencies such as XRP

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/exceptions/Exceptions.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/exceptions/Exceptions.scala
@@ -39,8 +39,13 @@ case class WalletPoolAlreadyExistException(poolName: String) extends {
 } with Exception(msg) with DaemonException
 
 case class CurrencyNotFoundException(currencyName: String) extends {
-  val msg = s"Currency $currencyName is not supported"
+  val msg = s"Currency $currencyName is not found"
   val code = ErrorCodes.CURRENCY_NOT_FOUND
+} with Exception(msg) with DaemonException
+
+case class CurrencyNotSupportedException(currencyName: String) extends {
+  val msg = s"Currency $currencyName is not supported"
+  val code = ErrorCodes.CURRENCY_NOT_SUPPORTED
 } with Exception(msg) with DaemonException
 
 case class UserNotFoundException(pubKey: String) extends {
@@ -84,6 +89,7 @@ object ErrorCodes {
   val CURRENCY_NOT_FOUND = 206
   val USER_NOT_FOUND = 207
   val USER_ALREADY_EXIST = 208
+  val CURRENCY_NOT_SUPPORTED = 209
   val CORE_BAD_REQUEST = 301
   val DAEMON_DATABASE_EXCEPTION = 302
 }

--- a/src/main/scala/co/ledger/wallet/daemon/mappers/DaemonExceptionMapper.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/mappers/DaemonExceptionMapper.scala
@@ -42,6 +42,10 @@ class DaemonExceptionMapper @Inject()(response: ResponseBuilder)
         ResponseSerializer.serializeBadRequest(
           daemonExceptionInfo(cnfe) + ("currency_name" -> cnfe.currencyName),
           response)
+      case cnfe: CurrencyNotSupportedException =>
+        ResponseSerializer.serializeBadRequest(
+          daemonExceptionInfo(cnfe) + ("currency_name" -> cnfe.currencyName),
+          response)
       case unfe: UserNotFoundException =>
         ResponseSerializer.serializeBadRequest(
           daemonExceptionInfo(unfe) + ("pub_key" -> unfe.pubKey),

--- a/src/main/scala/co/ledger/wallet/daemon/models/Currency.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Currency.scala
@@ -1,6 +1,7 @@
 package co.ledger.wallet.daemon.models
 
 import co.ledger.core
+import co.ledger.wallet.daemon.exceptions.CurrencyNotSupportedException
 import co.ledger.wallet.daemon.models.coins.Coin.NetworkParamsView
 import co.ledger.wallet.daemon.models.coins.{Bitcoin, EthereumNetworkParamView}
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -53,7 +54,7 @@ object Currency {
   private def newNetworkParamsView(coreCurrency: core.Currency): NetworkParamsView = coreCurrency.getWalletType match {
     case core.WalletType.BITCOIN => Bitcoin.newNetworkParamsView(coreCurrency.getBitcoinLikeNetworkParameters)
     case core.WalletType.ETHEREUM => EthereumNetworkParamView(coreCurrency.getEthereumLikeNetworkParameters)
-    case _ => throw new UnsupportedOperationException
+    case _ => throw CurrencyNotSupportedException(coreCurrency.getName)
   }
 }
 

--- a/src/main/scala/co/ledger/wallet/daemon/services/CurrenciesService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/CurrenciesService.scala
@@ -8,6 +8,7 @@ import co.ledger.wallet.daemon.models._
 import Currency._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 @Singleton
 class CurrenciesService @Inject()(daemonCache: DaemonCache) extends DaemonService {
@@ -18,7 +19,9 @@ class CurrenciesService @Inject()(daemonCache: DaemonCache) extends DaemonServic
   }
 
   def currencies(poolInfo: PoolInfo): Future[Seq[CurrencyView]] = {
-    daemonCache.getCurrencies(poolInfo).map { modelCs => modelCs.map(_.currencyView) }
+    daemonCache.getCurrencies(poolInfo).map { modelCs =>
+      modelCs.flatMap(c => Try(c.currencyView).toOption)
+    }
   }
 
   def validateAddress(address: String, currencyName: String, poolInfo: PoolInfo): Future[Boolean] = {


### PR DESCRIPTION
When building a `currencyView` for a currency not supported by the Daemon, we raise an exception. This prevents listing all currencies when one of them has not been yet implemented on the Daemon and by extension on the gate.

By skipping the currencies generating exceptions, we make ourselves more resilient to libcore changes.