### PR TITLE
Allow sending out the whole content of an erc20 account

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -198,7 +198,7 @@ object Account extends Logging {
               a.asEthereumLikeAccount().getERC20Accounts.asScala.find(_.getToken.getContractAddress == contract) match {
                 case Some(erc20Account) =>
                   val balance: scala.BigInt = erc20Account.getBalance.asScala
-                  if (balance > ti.amount) {
+                  if (balance >= ti.amount) {
                     val inputData = erc20Account.getTransferToAddressData(BigInt.fromIntegerString(ti.amount.toString(10), 10), ti.recipient)
                     val v = a.asEthereumLikeAccount().buildTransaction()
                       .sendToAddress(c.convertAmount(0), contract)


### PR DESCRIPTION
Unlike base currencies, it is possible to empty a token account by sending out all the tokens inside it since the fees are taken from the parent account.