### PR TITLE
Updated build-jar and lib-core jar to 4ff95fde

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -19,7 +19,7 @@ MACOS_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build
 LINUX_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build-linux
 JAR_BUILD_DIR=$CURRENT_DIR/../build-jar
 LIBCORE_AWS_URL_BASE="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
-LIBCORE_VERSION="2.7.0-rc-43d760"
+LIBCORE_VERSION="2.7.0-rc-4ff95f"
 LIBCORE_DL_DIR=$CURRENT_DIR/../lib-ledger-core-dl
 
 function gen_interface()


### PR DESCRIPTION
Pointing to a new version of the lib-core https://github.com/LedgerHQ/lib-ledger-core/commit/4ff95fde74511d2c0c882e7bc72406c84d7e8383