### PR TITLE
Change btc tx creation strategy to OPTIMIZE_SIZE

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -178,7 +178,7 @@ object Account extends Logging {
           }
           tx <- a.asBitcoinLikeAccount().buildTransaction(false)
             .sendToAddress(c.convertAmount(ti.amount), ti.recipient)
-            .pickInputs(BitcoinLikePickingStrategy.MERGE_OUTPUTS, UnsignedInteger.MAX_VALUE.intValue())
+            .pickInputs(BitcoinLikePickingStrategy.OPTIMIZE_SIZE, UnsignedInteger.MAX_VALUE.intValue())
             .setFeesPerByte(feesPerByte)
             .build()
           v <- Bitcoin.newUnsignedTransactionView(tx, feesPerByte.toBigInt.asScala)


### PR DESCRIPTION
This is a hot fix related to https://ledgerhq.atlassian.net/browse/LV-1678
**Note:**
This UTXO picking strategy was not tested yet in production, we have tests covering it and I ran several tests with xpub with a lot of UTXOS and it seems to work just fine.