### PR TITLE
Use the operation type of the erc20 op

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Operations.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Operations.scala
@@ -30,7 +30,7 @@ object Operations {
           case e: EthereumTransactionView => e.copy(erc20 = Some(ERC20.from(erc20Operation)))
           case _ => throw InvalidCurrencyForErc20Operation()
       }
-      view.copy(transaction = tvOpt)
+      view.copy(opType = erc20Operation.getOperationType, transaction = tvOpt)
     }
   }
 


### PR DESCRIPTION
The type of the transaction (SEND, RECEIVE, NONE) needs to come from the erc20 transaction, not the eth one as it can be None for eth and RECEIVE for erc20.