### PR TITLE
Bump libcore version to 3.1.0-rc-da6037

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -19,7 +19,7 @@ MACOS_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build
 LINUX_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build-linux
 JAR_BUILD_DIR=$CURRENT_DIR/../build-jar
 LIBCORE_AWS_URL_BASE="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
-LIBCORE_VERSION="3.1.0-rc-da6037"
+LIBCORE_VERSION="3.1.0-rc-494eed"
 
 function gen_interface()
 {


### PR DESCRIPTION
### What is this about?

Fixes libcore bug related to incorrect timestamps after account reconciliation.

### Cute picture of animal

![](https://media.tenor.com/images/4fc88e22972f63daee69c55089e68c76/tenor.gif)