### PR TITLE
Update lib-core to last version.

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -19,7 +19,8 @@ MACOS_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build
 LINUX_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build-linux
 JAR_BUILD_DIR=$CURRENT_DIR/../build-jar
 LIBCORE_AWS_URL_BASE="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
-LIBCORE_VERSION="3.1.0-rc-494eed"
+LIBCORE_VERSION="3.1.0-rc-5978dc"
+LIBCORE_DL_DIR=$CURRENT_DIR/../lib-ledger-core-dl
 
 function gen_interface()
 {


### PR DESCRIPTION
# Content

This PR updates the `build-jar.sh` to latestest libcore. Especially, that libcore contains the fix for ETH negative balances.

# Mandatory picture of CRAB

<sub>Click the crab!</sub>

[![](https://i.ytimg.com/vi/zGuXk7SlhqM/hqdefault.jpg)](https://www.youtube.com/watch?v=KDzt6yI3Dw8&t=1m17s)