### PR TITLE
Batch erc20 ops

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/controllers/AccountsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/AccountsController.scala
@@ -101,7 +101,7 @@ class AccountsController @Inject()(accountsService: AccountsService) extends Con
         info(s"GET account operations $request")
         request.contract match {
           case Some(contract) =>
-            accountsService.getERC20Operations(TokenAccountInfo(contract, request.accountInfo))
+            accountsService.getBatchedERC20Operations(TokenAccountInfo(contract, request.accountInfo), request.offset, request.batch)
           case None =>
             accountsService.accountOperations(OperationQueryParams(request.previous, request.next, request.batch, request.full_op), request.accountInfo)
         }
@@ -179,7 +179,7 @@ class AccountsController @Inject()(accountsService: AccountsService) extends Con
 
       // given token address, get the operations on this token
       get("/tokens/:token_address/operations") { request: TokenAccountRequest =>
-        accountsService.getERC20Operations(request.tokenAccountInfo)
+        accountsService.getBatchedERC20Operations(request.tokenAccountInfo, request.offset, request.batch)
       }
     }
   }
@@ -188,6 +188,7 @@ class AccountsController @Inject()(accountsService: AccountsService) extends Con
 
 object AccountsController {
   private val DEFAULT_BATCH: Int = 20
+  private val DEFAULT_OFFSET: Long = 0
   private val DEFAULT_OPERATION_MODE: Int = 0
 
 
@@ -272,6 +273,8 @@ object AccountsController {
                                   @RouteParam wallet_name: String,
                                   @RouteParam account_index: Int,
                                   @RouteParam token_address: String,
+                                  @QueryParam offset: Long = DEFAULT_OFFSET,
+                                  @QueryParam batch: Int = DEFAULT_BATCH,
                                   request: Request
                                 )
     extends BaseSingleAccountRequest with WithTokenAccountInfo
@@ -298,6 +301,7 @@ object AccountsController {
                                 @RouteParam override val account_index: Int,
                                 @QueryParam next: Option[UUID],
                                 @QueryParam previous: Option[UUID],
+                                @QueryParam offset: Long = DEFAULT_OFFSET,
                                 @QueryParam batch: Int = DEFAULT_BATCH,
                                 @QueryParam full_op: Int = DEFAULT_OPERATION_MODE,
                                 @QueryParam contract: Option[String],

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -41,6 +41,9 @@ object Account extends Logging {
     def erc20Operations(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
       Account.erc20Operations(a)
 
+    def batchedErc20Operations(contract: String, limit: Long, batch: Int)(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
+      Account.batchedErc20Operations(contract, a, limit, batch)
+
     def batchedErc20Operations(limit: Long, batch: Int)(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
       Account.batchedErc20Operations(a, limit, batch)
 
@@ -146,6 +149,9 @@ object Account extends Logging {
       erc20Ops.map(erc20Op => (hashToCoreOps(erc20Op.getHash), erc20Op))
     }
 
+  def batchedErc20Operations(contract: String, a: core.Account, offset: Long, batch: Int)(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
+    asERC20Account(contract, a).liftTo[Future].flatMap(erc20Acc => batchedErc20Operations(erc20Acc, offset, batch))
+  
   def batchedErc20Operations(a: core.Account, offset: Long, batch: Int)(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
     for {
       account <- asETHAccount(a).liftTo[Future]

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -147,7 +147,17 @@ class AccountsService @Inject()(daemonCache: DaemonCache) extends DaemonService 
           }
         }
     }
-  
+
+  def getBatchedERC20Operations(tokenAccountInfo: TokenAccountInfo, offset: Long, batch: Int): Future[List[OperationView]] =
+    daemonCache.withAccountAndWallet(tokenAccountInfo.accountInfo) {
+      case (account, wallet) =>
+        account.batchedErc20Operations(tokenAccountInfo.tokenAddress, offset, batch).flatMap { operations =>
+          operations.traverse { case (coreOp, erc20Op) =>
+            Operations.getErc20View(erc20Op, coreOp, wallet, account)
+          }
+        }
+    }
+
   def getBatchedERC20Operations(accountInfo: AccountInfo, offset: Long, batch: Int): Future[List[OperationView]] =
     daemonCache.withAccountAndWallet(accountInfo) {
       case (account, wallet) =>

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -147,6 +147,16 @@ class AccountsService @Inject()(daemonCache: DaemonCache) extends DaemonService 
           }
         }
     }
+  
+  def getBatchedERC20Operations(accountInfo: AccountInfo, offset: Long, batch: Int): Future[List[OperationView]] =
+    daemonCache.withAccountAndWallet(accountInfo) {
+      case (account, wallet) =>
+        account.batchedErc20Operations(offset, batch).flatMap { operations =>
+          operations.traverse { case (coreOp, erc20Op) =>
+            Operations.getErc20View(erc20Op, coreOp, wallet, account)
+          }
+        }
+    }
 
   def getTokenAccounts(accountInfo: AccountInfo): Future[List[ERC20AccountView]] =
     daemonCache.withAccount(accountInfo) { account =>


### PR DESCRIPTION
As discussed, this will paginate on Operations so it's always better than querying all Operations and all ERC20Operations ...
Best solution is to not use this call, query ERC20Operations by batching them, then map from Gate's side (because also Gate is supposed already to have Operations)
This will also avoid doing the complete query