### PR TITLE
Bump libcore to 8c9659

### DIFF
--- a/build-jar.sh
+++ b/build-jar.sh
@@ -14,17 +14,21 @@ COMMAND=$1
 OPT_COMMAND=$2
 
 DOCKER_NAME=lib-core-cmake
-INTERFACE_GEN_DIR=$CURRENT_DIR/tools/generate_interfaces.sh
 MACOS_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build
 LINUX_BUILD_DIR=$CURRENT_DIR/../lib-ledger-core-build-linux
 JAR_BUILD_DIR=$CURRENT_DIR/../build-jar
 LIBCORE_AWS_URL_BASE="https://s3-eu-west-1.amazonaws.com/ledger-lib-ledger-core"
-LIBCORE_VERSION="3.1.0-rc-494eed"
+LIBCORE_VERSION="3.1.0-rc-8c9659"
+LIBCORE_DL_DIR=$CURRENT_DIR/../lib-ledger-core-dl
+LIBCORE_SRC_DIR=$CURRENT_DIR/../lib-ledger-core
+INTERFACE_GEN_DIR=tools/generate_interfaces.sh
 
 function gen_interface()
 {
   rm -v -rf $CURRENT_DIR/api
+  cd $LIBCORE_SRC_DIR
   bash $INTERFACE_GEN_DIR
+  cd -
 }
 
 function clean_src()
@@ -100,8 +104,8 @@ function build_jar()
   gen_interface
   rm -v -rf $JAR_BUILD_DIR
   mkdir -v $JAR_BUILD_DIR
-  JAVA_API_DIR=$CURRENT_DIR/api/core/java
-  SCALA_API_DIR=$CURRENT_DIR/api/core/scala
+  JAVA_API_DIR=$LIBCORE_SRC_DIR/api/core/java
+  SCALA_API_DIR=$LIBCORE_SRC_DIR/api/core/scala
   RESOURCE_DIR=$JAR_BUILD_DIR/src/main/resources/resources/djinni_native_libs
 
   mkdir -v -p $RESOURCE_DIR

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -160,7 +160,7 @@ object Account extends Logging {
     } yield result
 
   private def batchedErc20Operations(a: core.ERC20LikeAccount, offset: Long, batch: Int)(implicit ec: ExecutionContext): Future[List[(core.Operation, core.ERC20LikeOperation)]] =
-    a.queryOperations().offset(offset).limit(batch).complete().execute().map(_.asScala.toList).map { coreOps =>
+    a.queryOperations().offset(offset).limit(batch).addOrder(OperationOrderKey.DATE, true).complete().execute().map(_.asScala.toList).map { coreOps =>
       val hashToERC20 = a.getOperations.asScala.toList.map(erc20Op => erc20Op.getHash -> erc20Op).toMap
       coreOps.map(coreOp => (coreOp, hashToERC20(coreOp.asEthereumLikeOperation().getTransaction.getHash)))
     }


### PR DESCRIPTION
Impact on Vault will be:
- Fix ETH: negative balance in `getBalanceHistory`,
- Fix ETH: Add order on pagination on ERC20OperationQuery,
- Fix XRP: using `server_state` instead of `server_info`,
- Feature: `isAddressActivated` available to check if an address has been activated. 