### PR TITLE
[Back-374] - partial transaction creation (calculate fees more quickly)

### DIFF
--- a/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
@@ -3,6 +3,7 @@ package co.ledger.wallet.daemon.api
 import co.ledger.wallet.daemon.utils.APIFeatureTest
 import com.twitter.finagle.http.{Response, Status}
 import org.junit.Test
+import org.scalatest.Tag
 
 @Test
 class TransactionsApiTest extends APIFeatureTest {
@@ -19,7 +20,23 @@ class TransactionsApiTest extends APIFeatureTest {
     super.afterAll()
   }
 
-  test("TransactionsApi#Create and sign transaction") {
+  /*
+      Bitcoin testnet account
+      BIP39 mnemonic : amount picture reward sorry local traffic response subject arrow tape silver stereo young path laugh leisure pitch lend drill elephant rural mushroom pill dice
+      BIP39 Seed : 8300c413fe76b06c7a6420143348410c494e98e22ed6ed894b399d6e19712d0beaf7674742ead88fda64d70a21da0618d8899c8caea77cc2a718a16c9f1b1b38
+      Account extended pubKey :             tpubDCvkaY3GEKQxpSpKaKNg4PNUzR42yr2XoKWWEMXaSE5gCouqUazcDpWXTGkFAkdGruCQtdTxHqHt8dbbTVfBCxvvwJHeMU4YPzWVLdoAL5H
+      Account extended private key :        tprv8gEiS8125wjHvynXgfi5eyiNRPY6pWqdE1uiwqVH1xHHNKf4rCB23KtfH9fbLW8azudGrvwQag5Jwg85qttNpfXdu9aBHssrZMZC5MtwujQ
+      BIP32 Account extended pubKey :       tpubDFZ7AWJ9LgCoS6NAhmY7BRcBg9TWnQEMUeLugE8XssxnTj32KdsMh6W7GfyB7QsXjhuPETS6FRWzQBMR9Xe3uNbtMeXBLVjSoUHSEka9VZJ
+      BIP32 Account extended private key :  tprv8is526FuCJX8YdLNp7sWn1x577wad53SuLk8Pi6ETcAPdEnFhF3mWbtF6YrzUpx8spPw3tgpPdW3u34qM6oXuqXdiNGLaaNpG1iJxJg9RMw
+      Derivations :
+                path,                 address,                                            public key,                                                   private key
+            m/44'/1'/0'/0/0,n1QJpnrS6fTjdT3q3bc8twB9t6AA6L9RXm,0276b49de71f3032ba98f2988ae0a00b8c10011183007f2701aff60de1b272e45d,cPHCq2vd5C3W1UXqRS9HpVHR9DYJguTjfwjk8weP4zHhZKAY3M3q
+            m/44'/1'/0'/0/1,mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU,030d222dcc39de637d1a6ff646d600f4e26aad5af3b6a0ab9f979d1d3fb5c01b91,cUyokwFBMPgjw2kT92cjF7bzqjyUtLe8pjdYgmRp4z2kHf8kAWXU
+            m/44'/1'/0'/0/2,mg4cBTMdZvkEbJAoMXDHyGDdjsqfjHzxQ6,035988c9617250f3a6d6e0e8e072bcf8bcb7f6802ffa4131b600e5afcca8bf47b2,cVytSayWDBWifQ6sXWgTJcFA1UW89YRUmQS13FQ6WoGLY612yPyz
+            m/44'/1'/0'/0/3,n2PFTg4FhNM1w6c1JEphsJwTEXGGmF5E6a,0315779ec3bf11fc6755323c8125e14e818508d96b27ffe9dff2b636ce01966260,cPVUBRNcjSJCSk1m5JLBz3uapTv4pZUmxyRJtT9sZtBjZoVvoVog
+ */
+
+  test("TransactionsApi#Create and sign transaction", Tag("ignore")) {
     val poolName = "transactionsCreation4Test"
     createPool(poolName)
     val walletName = "btcwallet"
@@ -112,20 +129,6 @@ class TransactionsApiTest extends APIFeatureTest {
     )
   }
 
-  /*
-BIP39 mnemonic : amount picture reward sorry local traffic response subject arrow tape silver stereo young path laugh leisure pitch lend drill elephant rural mushroom pill dice
-BIP39 Seed : 8300c413fe76b06c7a6420143348410c494e98e22ed6ed894b399d6e19712d0beaf7674742ead88fda64d70a21da0618d8899c8caea77cc2a718a16c9f1b1b38
-Account extended pubKey :             tpubDCvkaY3GEKQxpSpKaKNg4PNUzR42yr2XoKWWEMXaSE5gCouqUazcDpWXTGkFAkdGruCQtdTxHqHt8dbbTVfBCxvvwJHeMU4YPzWVLdoAL5H
-Account extended private key :        tprv8gEiS8125wjHvynXgfi5eyiNRPY6pWqdE1uiwqVH1xHHNKf4rCB23KtfH9fbLW8azudGrvwQag5Jwg85qttNpfXdu9aBHssrZMZC5MtwujQ
-BIP32 Account extended pubKey :       tpubDFZ7AWJ9LgCoS6NAhmY7BRcBg9TWnQEMUeLugE8XssxnTj32KdsMh6W7GfyB7QsXjhuPETS6FRWzQBMR9Xe3uNbtMeXBLVjSoUHSEka9VZJ
-BIP32 Account extended private key :  tprv8is526FuCJX8YdLNp7sWn1x577wad53SuLk8Pi6ETcAPdEnFhF3mWbtF6YrzUpx8spPw3tgpPdW3u34qM6oXuqXdiNGLaaNpG1iJxJg9RMw
-Derivations :
-          path,                 address,                                            public key,                                                   private key
-      m/44'/1'/0'/0/0,n1QJpnrS6fTjdT3q3bc8twB9t6AA6L9RXm,0276b49de71f3032ba98f2988ae0a00b8c10011183007f2701aff60de1b272e45d,cPHCq2vd5C3W1UXqRS9HpVHR9DYJguTjfwjk8weP4zHhZKAY3M3q
-      m/44'/1'/0'/0/1,mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU,030d222dcc39de637d1a6ff646d600f4e26aad5af3b6a0ab9f979d1d3fb5c01b91,cUyokwFBMPgjw2kT92cjF7bzqjyUtLe8pjdYgmRp4z2kHf8kAWXU
-      m/44'/1'/0'/0/2,mg4cBTMdZvkEbJAoMXDHyGDdjsqfjHzxQ6,035988c9617250f3a6d6e0e8e072bcf8bcb7f6802ffa4131b600e5afcca8bf47b2,cVytSayWDBWifQ6sXWgTJcFA1UW89YRUmQS13FQ6WoGLY612yPyz
-      m/44'/1'/0'/0/3,n2PFTg4FhNM1w6c1JEphsJwTEXGGmF5E6a,0315779ec3bf11fc6755323c8125e14e818508d96b27ffe9dff2b636ce01966260,cPVUBRNcjSJCSk1m5JLBz3uapTv4pZUmxyRJtT9sZtBjZoVvoVog
- */
   private val ACCOUNT_BODY =
     """{""" +
       """"account_index": 0,""" +

--- a/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
@@ -2,7 +2,9 @@ package co.ledger.wallet.daemon.api
 
 import co.ledger.wallet.daemon.utils.APIFeatureTest
 import com.twitter.finagle.http.{Response, Status}
+import org.junit.Test
 
+@Test
 class TransactionsApiTest extends APIFeatureTest {
 
   val poolName = "ledger"
@@ -17,20 +19,19 @@ class TransactionsApiTest extends APIFeatureTest {
     super.afterAll()
   }
 
-  // FIXME: Broken test
-  /*
   test("TransactionsApi#Create and sign transaction") {
-    val poolName = "transactionsAPI1"
+    val poolName = "transactionsCreation4Test"
     createPool(poolName)
-    assertWalletCreation(poolName, "wallet", "bitcoin", Status.Ok)
-    assertCreateAccount(ACCOUNT_BODY, poolName, "wallet", Status.Ok)
+    val walletName = "btcwallet"
+    assertWalletCreation(poolName, walletName, "bitcoin_testnet", Status.Ok)
+    assertCreateAccount(ACCOUNT_BODY, poolName, walletName, Status.Ok)
     assertSyncPool(Status.Ok)
-    assertCreateTransaction(TX_BODY_WITH_EXCLUDE_UTXO, poolName, "wallet", 0, Status.Ok)
-    assertCreateTransaction(TX_BODY, poolName, "wallet", 0, Status.BadRequest)
-    assertCreateTransaction(INVALID_FEE_LEVEL_BODY, poolName, "wallet", 0, Status.BadRequest)
-    assertSignTransaction(TX_MISSING_APPENDED_SIG, poolName, "wallet", 0, Status.BadRequest)
-    assertSignTransaction(TX_MISSING_ONE_SIG, poolName, "wallet", 0, Status.BadRequest)
-    assertSignTransaction(TX_TO_SIGN_BODY, poolName, "wallet", 0, Status.InternalServerError)
+    assertCreateTransaction(TX_BODY_WITH_EXCLUDE_UTXO, poolName, walletName, 0, Status.Ok)
+    assertCreateTransaction(TX_BODY, poolName, walletName, 0, Status.BadRequest)
+    assertCreateTransaction(INVALID_FEE_LEVEL_BODY, poolName, walletName, 0, Status.BadRequest)
+    assertSignTransaction(TX_MISSING_APPENDED_SIG, poolName, walletName, 0, Status.BadRequest)
+    assertSignTransaction(TX_MISSING_ONE_SIG, poolName, walletName, 0, Status.BadRequest)
+    assertSignTransaction(TX_TO_SIGN_BODY, poolName, walletName, 0, Status.InternalServerError)
   }
 
   private def assertCreateTransaction(tx: String, poolName: String, walletName: String, accountIndex: Int, expected: Status): Response = {
@@ -65,14 +66,14 @@ class TransactionsApiTest extends APIFeatureTest {
 
   private val INVALID_FEE_LEVEL_BODY =
     """{""" +
-      """"recipient": "36v1GRar68bBEyvGxi9RQvdP6Rgvdwn2C2",""" +
+      """"recipient": "mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU",""" +
       """"fees_level": "OTHER",""" +
       """"amount": 10000""" +
       """}"""
 
   private val TX_BODY =
     """{""" +
-      """"recipient": "36v1GRar68bBEyvGxi9RQvdP6Rgvdwn2C2",""" +
+      """"recipient": "mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU",""" +
       """"fees_per_byte": 397000,""" +
       """"fees_level": "FAST",""" +
       """"amount": 10000""" +
@@ -80,12 +81,11 @@ class TransactionsApiTest extends APIFeatureTest {
 
   private val TX_BODY_WITH_EXCLUDE_UTXO =
     """{""" +
-    """"recipient": "36v1GRar68bBEyvGxi9RQvdP6Rgvdwn2C2",""" +
+    """"recipient": "mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU",""" +
     """"fees_level": "NORMAL",""" +
-    """"amount": 20000000,""" +
-    """"exclude_utxos":{"beabf89d72eccdcb895373096a402ae48930aa54d2b9e4d01a05e8f068e9ea49": 0 }""" +
+    """"amount": 1000""" +
+//    """"exclude_utxos":{"beabf89d72eccdcb895373096a402ae48930aa54d2b9e4d01a05e8f068e9ea49": 0 }""" +
     """}"""
-  */
 
   test("AccountsApi#Broadcast signed transaction") {
     assertWalletCreation(poolName, "bitcoin_testnet", "bitcoin_testnet", Status.Ok)
@@ -112,20 +112,34 @@ class TransactionsApiTest extends APIFeatureTest {
     )
   }
 
+  /*
+BIP39 mnemonic : amount picture reward sorry local traffic response subject arrow tape silver stereo young path laugh leisure pitch lend drill elephant rural mushroom pill dice
+BIP39 Seed : 8300c413fe76b06c7a6420143348410c494e98e22ed6ed894b399d6e19712d0beaf7674742ead88fda64d70a21da0618d8899c8caea77cc2a718a16c9f1b1b38
+Account extended pubKey :             tpubDCvkaY3GEKQxpSpKaKNg4PNUzR42yr2XoKWWEMXaSE5gCouqUazcDpWXTGkFAkdGruCQtdTxHqHt8dbbTVfBCxvvwJHeMU4YPzWVLdoAL5H
+Account extended private key :        tprv8gEiS8125wjHvynXgfi5eyiNRPY6pWqdE1uiwqVH1xHHNKf4rCB23KtfH9fbLW8azudGrvwQag5Jwg85qttNpfXdu9aBHssrZMZC5MtwujQ
+BIP32 Account extended pubKey :       tpubDFZ7AWJ9LgCoS6NAhmY7BRcBg9TWnQEMUeLugE8XssxnTj32KdsMh6W7GfyB7QsXjhuPETS6FRWzQBMR9Xe3uNbtMeXBLVjSoUHSEka9VZJ
+BIP32 Account extended private key :  tprv8is526FuCJX8YdLNp7sWn1x577wad53SuLk8Pi6ETcAPdEnFhF3mWbtF6YrzUpx8spPw3tgpPdW3u34qM6oXuqXdiNGLaaNpG1iJxJg9RMw
+Derivations :
+          path,                 address,                                            public key,                                                   private key
+      m/44'/1'/0'/0/0,n1QJpnrS6fTjdT3q3bc8twB9t6AA6L9RXm,0276b49de71f3032ba98f2988ae0a00b8c10011183007f2701aff60de1b272e45d,cPHCq2vd5C3W1UXqRS9HpVHR9DYJguTjfwjk8weP4zHhZKAY3M3q
+      m/44'/1'/0'/0/1,mxZcpwZ7XBdfb4JcGLzdEP8WPQaGzeUeFU,030d222dcc39de637d1a6ff646d600f4e26aad5af3b6a0ab9f979d1d3fb5c01b91,cUyokwFBMPgjw2kT92cjF7bzqjyUtLe8pjdYgmRp4z2kHf8kAWXU
+      m/44'/1'/0'/0/2,mg4cBTMdZvkEbJAoMXDHyGDdjsqfjHzxQ6,035988c9617250f3a6d6e0e8e072bcf8bcb7f6802ffa4131b600e5afcca8bf47b2,cVytSayWDBWifQ6sXWgTJcFA1UW89YRUmQS13FQ6WoGLY612yPyz
+      m/44'/1'/0'/0/3,n2PFTg4FhNM1w6c1JEphsJwTEXGGmF5E6a,0315779ec3bf11fc6755323c8125e14e818508d96b27ffe9dff2b636ce01966260,cPVUBRNcjSJCSk1m5JLBz3uapTv4pZUmxyRJtT9sZtBjZoVvoVog
+ */
   private val ACCOUNT_BODY =
     """{""" +
       """"account_index": 0,""" +
       """"derivations": [""" +
       """{""" +
       """"owner": "main",""" +
-      """"path": "44'/0'/0'",""" +
-      """"pub_key": "0437bc83a377ea025e53eafcd18f299268d1cecae89b4f15401926a0f8b006c0f7ee1b995047b3e15959c5d10dd1563e22a2e6e4be9572aa7078e32f317677a901",""" +
+      """"path": "44'/1'/0'",""" +
+      """"pub_key": "0276b49de71f3032ba98f2988ae0a00b8c10011183007f2701aff60de1b272e45d",""" +
       """"chain_code": "d1bb833ecd3beed6ec5f6aa79d3a424d53f5b99147b21dbc00456b05bc978a71"""" +
       """},""" +
       """{""" +
       """"owner": "main",""" +
-      """"path": "44'/0'",""" +
-      """"pub_key": "04fb60043afe80ee1aeb0160e2aafc94690fb4427343e8d4bf410105b1121f7a44a311668fa80a7a341554a4ef5262bc6ebd8cc981b8b600dafd40f7682edb5b3b",""" +
+      """"path": "44'/1'",""" +
+      """"pub_key": "030d222dcc39de637d1a6ff646d600f4e26aad5af3b6a0ab9f979d1d3fb5c01b91",""" +
       """"chain_code": "88c2281acd51737c912af74cc1d1a8ba564eb7925e0d58a5500b004ba76099cb"""" +
       """}""" +
       """]""" +

--- a/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/api/TransactionsApiTest.scala
@@ -3,7 +3,6 @@ package co.ledger.wallet.daemon.api
 import co.ledger.wallet.daemon.utils.APIFeatureTest
 import com.twitter.finagle.http.{Response, Status}
 import org.junit.Test
-import org.scalatest.Tag
 
 @Test
 class TransactionsApiTest extends APIFeatureTest {
@@ -35,8 +34,8 @@ class TransactionsApiTest extends APIFeatureTest {
             m/44'/1'/0'/0/2,mg4cBTMdZvkEbJAoMXDHyGDdjsqfjHzxQ6,035988c9617250f3a6d6e0e8e072bcf8bcb7f6802ffa4131b600e5afcca8bf47b2,cVytSayWDBWifQ6sXWgTJcFA1UW89YRUmQS13FQ6WoGLY612yPyz
             m/44'/1'/0'/0/3,n2PFTg4FhNM1w6c1JEphsJwTEXGGmF5E6a,0315779ec3bf11fc6755323c8125e14e818508d96b27ffe9dff2b636ce01966260,cPVUBRNcjSJCSk1m5JLBz3uapTv4pZUmxyRJtT9sZtBjZoVvoVog
  */
-
-  test("TransactionsApi#Create and sign transaction", Tag("ignore")) {
+  // Ignored : TODO BACK-375
+  ignore("TransactionsApi#Create and sign transaction") {
     val poolName = "transactionsCreation4Test"
     createPool(poolName)
     val walletName = "btcwallet"

--- a/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
@@ -24,6 +24,7 @@ class TransactionsController @Inject()(transactionsService: TransactionsService)
     * fees_level: optional(SLOW, FAST, NORMAL),
     * amount: in satoshi,
     * exclude_utxos: map{txHash: index}
+    * partial_tx : optional(boolean) - lightweight mode can be used in order to calculate fees, partial mode avoid costly calls to retrieve unnecessary UTXOs info
     * }
     *
     */
@@ -131,13 +132,13 @@ object TransactionsController {
                                          fees_level: Option[String],
                                          amount: String,
                                          exclude_utxos: Option[Map[String, Int]],
-                                         partialTransac: Option[Boolean]
+                                         partialTx: Option[Boolean],
                                         ) extends CreateTransactionRequest {
     def amountValue: BigInt = BigInt(amount)
 
     def feesPerByteValue: Option[BigInt] = fees_per_byte.map(BigInt(_))
 
-    def transactionInfo: BTCTransactionInfo = BTCTransactionInfo(recipient, feesPerByteValue, fees_level, amountValue, exclude_utxos.getOrElse(Map[String, Int]()), partialTransac)
+    def transactionInfo: BTCTransactionInfo = BTCTransactionInfo(recipient, feesPerByteValue, fees_level, amountValue, exclude_utxos.getOrElse(Map[String, Int]()), partialTx)
 
     @MethodValidation
     def validateFees: ValidationResult = CommonMethodValidations.validateFees(feesPerByteValue, fees_level)
@@ -162,7 +163,12 @@ object TransactionsController {
 
   trait  TransactionInfo
 
-  case class BTCTransactionInfo(recipient: String, feeAmount: Option[BigInt], feeLevel: Option[String], amount: BigInt, excludeUtxos: Map[String, Int], partialTransac: Option[Boolean]) extends TransactionInfo {
+  case class BTCTransactionInfo(recipient: String,
+                                feeAmount: Option[BigInt],
+                                feeLevel: Option[String],
+                                amount: BigInt,
+                                excludeUtxos: Map[String, Int],
+                                partialTx: Option[Boolean]) extends TransactionInfo {
     lazy val feeMethod: Option[FeeMethod] = feeLevel.map { level => FeeMethod.from(level) }
   }
 

--- a/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
@@ -24,7 +24,7 @@ class TransactionsController @Inject()(transactionsService: TransactionsService)
     * fees_level: optional(SLOW, FAST, NORMAL),
     * amount: in satoshi,
     * exclude_utxos: map{txHash: index}
-    * partial_tx : optional(boolean) - lightweight mode can be used in order to calculate fees, partial mode avoid costly calls to retrieve unnecessary UTXOs info
+    * partial_tx: optional(boolean) - lightweight mode can be used in order to calculate fees, partial mode avoid costly calls to retrieve unnecessary UTXOs info
     * }
     *
     */
@@ -54,8 +54,7 @@ object TransactionsController {
   case class AccountInfoRequest(@RouteParam pool_name: String,
                                 @RouteParam wallet_name: String,
                                 @RouteParam account_index: Int,
-                                request: Request
-                               ) extends RequestWithUser {
+                                request: Request) extends RequestWithUser {
     def accountInfo: AccountInfo = AccountInfo(account_index, wallet_name, pool_name, user.pubKey)
   }
 
@@ -66,7 +65,6 @@ object TransactionsController {
                                             request: Request
                                            ) extends BroadcastTransactionRequest {
     def hexTx: Array[Byte] = HexUtils.valueOf(raw_transaction)
-
     def hexSig: Array[Byte] = HexUtils.valueOf(signatures.head)
 
     @MethodValidation
@@ -82,7 +80,6 @@ object TransactionsController {
                                             request: Request
                                            ) extends BroadcastTransactionRequest {
     def rawTx: Array[Byte] = HexUtils.valueOf(raw_transaction)
-
     def pairedSignatures: Seq[(Array[Byte], Array[Byte])] = signatures.zipWithIndex.map { case (sig, index) =>
       (HexUtils.valueOf(sig), HexUtils.valueOf(pubkeys(index)))
     }
@@ -102,7 +99,6 @@ object TransactionsController {
                                             request: Request
                                            ) extends BroadcastTransactionRequest {
     def hexTx: Array[Byte] = HexUtils.valueOf(raw_transaction)
-
     def hexSig: Array[Byte] = HexUtils.valueOf(signatures.head)
 
     @MethodValidation
@@ -119,9 +115,7 @@ object TransactionsController {
                                          contract: Option[String]
                                         ) extends CreateTransactionRequest {
     def amountValue: BigInt = BigInt(amount)
-
     def gasLimitValue: Option[BigInt] = gas_limit.map(BigInt(_))
-
     def gasPriceValue: Option[BigInt] = gas_price.map(BigInt(_))
 
     override def transactionInfo: TransactionInfo = ETHTransactionInfo(recipient, amountValue, gasLimitValue, gasPriceValue, contract)
@@ -132,10 +126,9 @@ object TransactionsController {
                                          fees_level: Option[String],
                                          amount: String,
                                          exclude_utxos: Option[Map[String, Int]],
-                                         partialTx: Option[Boolean],
+                                         partialTx: Option[Boolean]
                                         ) extends CreateTransactionRequest {
     def amountValue: BigInt = BigInt(amount)
-
     def feesPerByteValue: Option[BigInt] = fees_per_byte.map(BigInt(_))
 
     def transactionInfo: BTCTransactionInfo = BTCTransactionInfo(recipient, feesPerByteValue, fees_level, amountValue, exclude_utxos.getOrElse(Map[String, Int]()), partialTx)
@@ -149,13 +142,12 @@ object TransactionsController {
   case class XRPSendToRequest(amount: String, address: String)
 
   case class CreateXRPTransactionRequest(send_to: List[XRPSendToRequest], // Send funds to the given address.
-                                         wipe_to: Option[String], // Send all available funds to the given address.
-                                         fees: Option[String], // Fees (in drop) the originator is willing to pay
-                                         memos: List[RippleLikeMemo], // Memos to add for this transaction
-                                         destination_tag: Option[Long] // An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
+                                         wipe_to: Option[String],         // Send all available funds to the given address.
+                                         fees: Option[String],            // Fees (in drop) the originator is willing to pay
+                                         memos: List[RippleLikeMemo],     // Memos to add for this transaction
+                                         destination_tag: Option[Long]    // An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
                                         ) extends CreateTransactionRequest {
     def sendToValue: List[XRPSendTo] = send_to.map { r => XRPSendTo(BigInt(r.amount), r.address) }
-
     def feesValue: Option[BigInt] = fees.map(BigInt(_))
 
     override def transactionInfo: TransactionInfo = XRPTransactionInfo(sendToValue, wipe_to, feesValue: Option[BigInt], memos, destination_tag)
@@ -175,5 +167,4 @@ object TransactionsController {
   case class ETHTransactionInfo(recipient: String, amount: BigInt, gasLimit: Option[BigInt], gasPrice: Option[BigInt], contract: Option[String]) extends TransactionInfo
 
   case class XRPTransactionInfo(sendTo: List[XRPSendTo], wipeTo: Option[String], fees: Option[BigInt], memos: List[RippleLikeMemo], destinationTag: Option[Long]) extends TransactionInfo
-
 }

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -223,7 +223,7 @@ object Account extends Logging {
   }
 
   private def createBTCTransaction(ti: BTCTransactionInfo, a: core.Account, c: core.Currency)(implicit ec: ExecutionContext): Future[TransactionView] = {
-   val partial: Boolean = ti.partialTransac.getOrElse(false)
+    val partial: Boolean = ti.partialTx.getOrElse(false)
     for {
       feesPerByte <- ti.feeAmount match {
         case Some(amount) => Future.successful(c.convertAmount(amount))


### PR DESCRIPTION
This enable partial btc like transac creation in order to avoid unnecessary costly operation on UTXOs info retrieval