### PR TITLE
[BACK-403] refactor and safe closing policy for lib-core http client

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClient.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClient.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedInputStream, DataOutputStream}
 import java.net.{HttpURLConnection, InetSocketAddress, URL}
 import java.util
 
-import co.ledger.core.{ErrorCode, HttpMethod, HttpReadBodyResult, HttpRequest, HttpUrlConnection}
+import co.ledger.core._
 import co.ledger.wallet.daemon.configurations.DaemonConfiguration
 import com.sun.xml.internal.messaging.saaj.util.ByteOutputStream
 import com.twitter.inject.Logging
@@ -27,63 +27,71 @@ class ScalaHttpClient(implicit val ec: ExecutionContext) extends co.ledger.core.
               new InetSocketAddress(proxy.host, proxy.port)))
           .asInstanceOf[HttpURLConnection]
     }
-    connection.setRequestMethod(resolveMethod(request.getMethod))
-    for ((key, value) <- request.getHeaders.asScala) {
-       connection.setRequestProperty(key, value)
-    }
-    connection.setRequestProperty("Content-Type", "application/json")
-    info(s"${request.getMethod} ${request.getUrl}")
-    val body = request.getBody
-    if (body.nonEmpty) {
-      connection.setDoOutput(true)
-      val dataOs = new DataOutputStream(connection.getOutputStream)
-      dataOs.write(body)
-      dataOs.flush()
-      dataOs.close()
-    }
-    val statusCode = connection.getResponseCode
-    val statusText = connection.getResponseMessage
-    val isError = !(statusCode >= 200 && statusCode < 400)
-    val response =
-      new BufferedInputStream(if (!isError) connection.getInputStream else connection.getErrorStream)
-    val headers = new util.HashMap[String, String]()
-    for ((key, list) <- connection.getHeaderFields.asScala) {
-      headers.put(key, list.get(list.size() - 1))
-    }
-    val proxy: HttpUrlConnection = new co.ledger.core.HttpUrlConnection() {
-      private val buffer = new Array[Byte](PROXY_BUFFER_SIZE)
-
-      override def getStatusCode: Int = statusCode
-
-      override def getStatusText: String = statusText
-
-      override def getHeaders: util.HashMap[String, String] = headers
-
-      override def readBody(): HttpReadBodyResult = {
+    try{
+      connection.setRequestMethod(resolveMethod(request.getMethod))
+      for ((key, value) <- request.getHeaders.asScala) {
+        connection.setRequestProperty(key, value)
+      }
+      connection.setRequestProperty("Content-Type", "application/json")
+      info(s"${request.getMethod} ${request.getUrl}")
+      val body = request.getBody
+      if (body.nonEmpty) {
+        connection.setDoOutput(true)
+        val dataOs = new DataOutputStream(connection.getOutputStream)
         try {
+          dataOs.write(body)
+          dataOs.flush()
+        }
+        finally dataOs.close()
+      }
+      val statusCode = connection.getResponseCode
+      val statusText = connection.getResponseMessage
+      val isError = !(statusCode >= 200 && statusCode < 400)
+      val response =
+        new BufferedInputStream(if (!isError) connection.getInputStream else connection.getErrorStream)
+      val headers = new util.HashMap[String, String]()
+      for ((key, list) <- connection.getHeaderFields.asScala) {
+        headers.put(key, list.get(list.size() - 1))
+      }
+      val proxy: HttpUrlConnection = new co.ledger.core.HttpUrlConnection() {
+        private val buffer = new Array[Byte](PROXY_BUFFER_SIZE)
+
+        override def getStatusCode: Int = statusCode
+
+        override def getStatusText: String = statusText
+
+        override def getHeaders: util.HashMap[String, String] = headers
+
+        override def readBody(): HttpReadBodyResult = {
           val outputStream = new ByteOutputStream()
-          var size = 0
-          do {
-            size = response.read(buffer)
-            if (size < buffer.length) {
-              outputStream.write(buffer.slice(0, size))
-            } else {
-              outputStream.write(buffer)
-            }
-          } while (size > 0)
-          val data = outputStream.getBytes
-          if (isError) info(s"Received error ${new String(data)}")
-          new HttpReadBodyResult(null, data)
-        } catch {
-          case t: Throwable =>
-            t.printStackTrace()
-            val error = new co.ledger.core.Error(ErrorCode.HTTP_ERROR, "An error happened during body reading.")
-            new HttpReadBodyResult(error, null)
-        } finally {
-          response.close()
-          connection.disconnect()
+          try {
+            var size = 0
+            do {
+              size = response.read(buffer)
+              if (size < buffer.length) {
+                outputStream.write(buffer.slice(0, size))
+              } else {
+                outputStream.write(buffer)
+              }
+            } while (size > 0)
+            val data = outputStream.getBytes
+            if (isError) info(s"Received error ${new String(data)}")
+            new HttpReadBodyResult(null, data)
+          } catch {
+            case t: Throwable =>
+              logger.error("Failed to read response body", t)
+              val error = new co.ledger.core.Error(ErrorCode.HTTP_ERROR, "An error happened during body reading.")
+              new HttpReadBodyResult(error, null)
+          } finally {
+            outputStream.close()
+            response.close()
+            connection.disconnect()
+          }
         }
       }
+    }
+    finally {
+      connection.disconnect()
     }
     request.complete(proxy, null)
   }.failed.map[co.ledger.core.Error]({
@@ -100,5 +108,5 @@ class ScalaHttpClient(implicit val ec: ExecutionContext) extends co.ledger.core.
 }
 
 object ScalaHttpClient {
-  val PROXY_BUFFER_SIZE: Int = 4*4096
+  val PROXY_BUFFER_SIZE: Int = 4 * 4096
 }

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClient.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClient.scala
@@ -1,6 +1,6 @@
 package co.ledger.wallet.daemon.clients
 
-import java.io.{BufferedInputStream, DataOutputStream}
+import java.io.{BufferedInputStream, DataOutputStream, OutputStream}
 import java.net.{HttpURLConnection, InetSocketAddress, URL}
 import java.util
 
@@ -17,7 +17,66 @@ class ScalaHttpClient(implicit val ec: ExecutionContext) extends co.ledger.core.
   import ScalaHttpClient._
 
   override def execute(request: HttpRequest): Unit = Future {
-    val connection = DaemonConfiguration.proxy match {
+    val connection = createConnection(request)
+
+    try {
+      info(s"${request.getMethod} ${request.getUrl}")
+      setRequestProperties(request, connection)
+
+      if (request.getBody.nonEmpty) {
+        connection.setDoOutput(true)
+        readRequestBody(request, connection.getOutputStream)
+      }
+
+      val statusCode = connection.getResponseCode
+      val statusText = connection.getResponseMessage
+      val isError = isOnError(statusCode)
+
+      info(s"Received from ${request.getUrl} status=$statusCode error=$isError - statusText=$statusText")
+
+      val headers: util.HashMap[String, String] = getResponseHeaders(connection)
+      val bodyResult: HttpReadBodyResult = readResponseBody(connection, isError)
+      val proxy: HttpUrlConnection = new ScalaHttpUrlConnection(statusCode, statusText, headers, bodyResult)
+      request.complete(proxy, null)
+    }
+    finally connection.disconnect()
+  }.failed.map[co.ledger.core.Error]({
+    others: Throwable =>
+      new co.ledger.core.Error(ErrorCode.HTTP_ERROR, others.getMessage)
+  }).foreach(request.complete(null, _))
+
+  private def getResponseHeaders(connection: HttpURLConnection) = {
+    val headers = new util.HashMap[String, String]()
+    for ((key, list) <- connection.getHeaderFields.asScala) {
+      headers.put(key, list.get(list.size() - 1))
+    }
+    headers
+  }
+
+  private def isOnError(statusCode: Int) = {
+    !(statusCode >= 200 && statusCode < 400)
+  }
+
+  private def readRequestBody(request: HttpRequest, os: OutputStream) = {
+    val dataOs = new DataOutputStream(os)
+    try {
+      dataOs.write(request.getBody)
+      dataOs.flush()
+    }
+    finally dataOs.close()
+  }
+
+  private def setRequestProperties(request: HttpRequest, connection: HttpURLConnection) = {
+    connection.setRequestMethod(resolveMethod(request.getMethod))
+    for ((key, value) <- request.getHeaders.asScala) {
+      connection.setRequestProperty(key, value)
+    }
+    connection.setRequestProperty("User-Agent", "ledger-lib-core")
+    connection.setRequestProperty("Content-Type", "application/json")
+  }
+
+  private def createConnection(request: HttpRequest) = {
+    DaemonConfiguration.proxy match {
       case None => new URL(request.getUrl).openConnection().asInstanceOf[HttpURLConnection]
       case Some(proxy) =>
         new URL(request.getUrl)
@@ -27,77 +86,36 @@ class ScalaHttpClient(implicit val ec: ExecutionContext) extends co.ledger.core.
               new InetSocketAddress(proxy.host, proxy.port)))
           .asInstanceOf[HttpURLConnection]
     }
-    try{
-      connection.setRequestMethod(resolveMethod(request.getMethod))
-      for ((key, value) <- request.getHeaders.asScala) {
-        connection.setRequestProperty(key, value)
-      }
-      connection.setRequestProperty("Content-Type", "application/json")
-      info(s"${request.getMethod} ${request.getUrl}")
-      val body = request.getBody
-      if (body.nonEmpty) {
-        connection.setDoOutput(true)
-        val dataOs = new DataOutputStream(connection.getOutputStream)
-        try {
-          dataOs.write(body)
-          dataOs.flush()
+  }
+
+  private def readResponseBody(connection: HttpURLConnection, onError: Boolean): HttpReadBodyResult = {
+    val response =
+      new BufferedInputStream(if (!onError) connection.getInputStream else connection.getErrorStream)
+    val buffer = new Array[Byte](PROXY_BUFFER_SIZE)
+    val outputStream = new ByteOutputStream()
+    try {
+      var size = 0
+      do {
+        size = response.read(buffer)
+        if (size < buffer.length) {
+          outputStream.write(buffer.slice(0, size))
+        } else {
+          outputStream.write(buffer)
         }
-        finally dataOs.close()
-      }
-      val statusCode = connection.getResponseCode
-      val statusText = connection.getResponseMessage
-      val isError = !(statusCode >= 200 && statusCode < 400)
-      val response =
-        new BufferedInputStream(if (!isError) connection.getInputStream else connection.getErrorStream)
-      val headers = new util.HashMap[String, String]()
-      for ((key, list) <- connection.getHeaderFields.asScala) {
-        headers.put(key, list.get(list.size() - 1))
-      }
-      val proxy: HttpUrlConnection = new co.ledger.core.HttpUrlConnection() {
-        private val buffer = new Array[Byte](PROXY_BUFFER_SIZE)
-
-        override def getStatusCode: Int = statusCode
-
-        override def getStatusText: String = statusText
-
-        override def getHeaders: util.HashMap[String, String] = headers
-
-        override def readBody(): HttpReadBodyResult = {
-          val outputStream = new ByteOutputStream()
-          try {
-            var size = 0
-            do {
-              size = response.read(buffer)
-              if (size < buffer.length) {
-                outputStream.write(buffer.slice(0, size))
-              } else {
-                outputStream.write(buffer)
-              }
-            } while (size > 0)
-            val data = outputStream.getBytes
-            if (isError) info(s"Received error ${new String(data)}")
-            new HttpReadBodyResult(null, data)
-          } catch {
-            case t: Throwable =>
-              logger.error("Failed to read response body", t)
-              val error = new co.ledger.core.Error(ErrorCode.HTTP_ERROR, "An error happened during body reading.")
-              new HttpReadBodyResult(error, null)
-          } finally {
-            outputStream.close()
-            response.close()
-            connection.disconnect()
-          }
-        }
-      }
+      } while (size > 0)
+      val data = outputStream.getBytes
+      if (onError) info(s"Received ${new String(data)}")
+      new HttpReadBodyResult(null, data)
+    } catch {
+      case t: Throwable =>
+        logger.error("Failed to read response body", t)
+        val error = new co.ledger.core.Error(ErrorCode.HTTP_ERROR, "An error happened during body reading.")
+        new HttpReadBodyResult(error, null)
+    } finally {
+      outputStream.close()
+      response.close()
     }
-    finally {
-      connection.disconnect()
-    }
-    request.complete(proxy, null)
-  }.failed.map[co.ledger.core.Error]({
-    others: Throwable =>
-      new co.ledger.core.Error(ErrorCode.HTTP_ERROR, others.getMessage)
-  }).foreach(request.complete(null, _))
+  }
 
   private def resolveMethod(method: HttpMethod) = method match {
     case HttpMethod.GET => "GET"

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpUrlConnection.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpUrlConnection.scala
@@ -1,0 +1,27 @@
+package co.ledger.wallet.daemon.clients
+
+import java.util
+
+import co.ledger.core.HttpReadBodyResult
+
+/**
+  * Wrapper for already computed results
+  * @param statusCode : Http return code
+  * @param statusText : Status massage
+  * @param headers : Map for header attributes
+  * @param bodyResult : The body returned
+  */
+class ScalaHttpUrlConnection(statusCode: Int, statusText: String,
+                             headers: util.HashMap[String, String],
+                             bodyResult: HttpReadBodyResult) extends co.ledger.core.HttpUrlConnection() {
+
+  override def getStatusCode: Int = statusCode
+
+  override def getStatusText: String = statusText
+
+  override def getHeaders: util.HashMap[String, String] = headers
+
+  override def readBody(): HttpReadBodyResult = {
+    bodyResult
+  }
+}


### PR DESCRIPTION
Ensure connection is closed enven if error are thrown at read body time or on core side
Refactor a bit ScalaHttpClient by isolate action inside methods