### PR TITLE
Back-501 : list utxos for BTC Accounts

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/controllers/AccountsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/AccountsController.scala
@@ -150,6 +150,11 @@ class AccountsController @Inject()(accountsService: AccountsService) extends Con
         accountsService.synchronizeAccount(request.accountInfo)
       }
 
+      // List of utxos available on this account
+      get("/utxo") { request: UtxoAccountRequest =>
+        accountsService.getUtxo(request.accountInfo, request.offset, request.batch)
+      }
+
       // List of tokens on this account
       get("/tokens") { request: AccountRequest =>
         accountsService.getTokenAccounts(request.accountInfo)
@@ -273,6 +278,16 @@ object AccountsController {
                                   request: Request
                                 )
     extends BaseSingleAccountRequest with WithTokenAccountInfo
+
+  case class UtxoAccountRequest(
+                                 @RouteParam pool_name: String,
+                                 @RouteParam wallet_name: String,
+                                 @RouteParam account_index: Int,
+                                 @QueryParam offset: Int = 0,
+                                 @QueryParam batch: Int = Int.MaxValue,
+                                 request: Request
+                               )
+    extends BaseSingleAccountRequest
 
   case class AccountCreationInfoRequest(
                                          @RouteParam pool_name: String,

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -59,6 +59,10 @@ object Account extends Logging {
     def erc20Account(tokenAddress: String): Either[Exception, core.ERC20LikeAccount] =
       asERC20Account(tokenAddress, a)
 
+    def getUtxo(offset: Int, batch: Int)(implicit ec: ExecutionContext): Future[List[co.ledger.core.BitcoinLikeOutput]] = {
+      Account.getUtxo(offset, batch, a)
+    }
+
     def balance(implicit ec: ExecutionContext): Future[scala.BigInt] =
       Account.balance(a)
 
@@ -124,6 +128,10 @@ object Account extends Logging {
         warn(s"Requested an erc20 account but it has not been found : $contract")
         Left(ERC20NotFoundException(contract))
     })
+  }
+
+  def getUtxo(offset: Int, batch: Int, a: core.Account)(implicit ex: ExecutionContext): Future[List[co.ledger.core.BitcoinLikeOutput]] = {
+    a.asBitcoinLikeAccount().getUTXO(offset, offset + batch).map(_.asScala.toList)
   }
 
   def erc20Accounts(a: core.Account): Either[Exception, List[core.ERC20LikeAccount]] =
@@ -505,3 +513,10 @@ case class FreshAddressView(
                              @JsonProperty("address") address: String,
                              @JsonProperty("derivation_path") derivation: String
                            )
+
+case class UTXOView(
+                     @JsonProperty("address") address: String,
+                     @JsonProperty("height") height: Long,
+                     @JsonProperty("confirmations") confirmations: Long,
+                     @JsonProperty("amount") amount: scala.BigInt
+                   )


### PR DESCRIPTION
Expose the ability to list utxo from BTC accounts
- Test are not complete as there is no available account ready for this scenario on tests (ie with utxo on it) need to integrate an account with utxos
- The only test done for now is check that service is returning 200 http code
- Number of confirmation are not available yet so we are returning 0 for now

Usage Exemple :
`/pools/:pool_name:/wallets/:wallet_name:/accounts/:idx:/utxo?offset=3&batch=5`

Where _offset_ is the index of utxo from which we want to list and _batch_ the maximum size of returned list. If non of them are provided default values are _offset=0_ & _batch=Integer.MAX_VALUE_