### PR TITLE
[Back-582] fees harmonization across coins 

### DIFF
--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -272,4 +272,15 @@ explorer = {
   }
 }
 
+ethereum = {
+  feesfactor = {
+      slow = 0.75
+      slow = ${?ETH_SLOW_FEE_FACTOR}
+      normal = 1.0
+      normal = ${?ETH_NORMAL_FEE_FACTOR}
+      fast = 1.25
+      fast = ${?ETH_FAST_FEE_FACTOR}
+  }
+}
+
 native_segwit_currencies = ["bitcoin", "bitcoin_testnet", "litecoin", "qtum"]

--- a/src/it/scala/co/ledger/wallet/daemon/api/AccountsApiTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/api/AccountsApiTest.scala
@@ -301,35 +301,6 @@ class AccountsApiTest extends APIFeatureTest {
     deletePool("op_pool_mal")
   }
 
-  private val CORRECT_BODY_XRP =
-    """{""" +
-      """"account_index": 0,""" +
-      """"derivations": [""" +
-      """{""" +
-      """"owner": "main",""" +
-      """"path": "44'/144'/2'",""" +
-      """"pub_key": "03432A07E9AE9D557F160D9B1856F909E421B399E12673EEE0F4045F4F7BA151CF",""" +
-      """"chain_code": "5D958E80B0373FA505B95C1DD175B0588205D1620C56F7247B028EBCB0FB5032"""" +
-      """}""" +
-      """]""" +
-      """}"""
-
-
-  test("AccountsApi#Create XRP account") {
-    val poolName = "op_pool"
-    val walletName = "xrpWallet"
-    createPool(poolName)
-    assertWalletCreation(poolName, walletName, "ripple", Status.Ok)
-    assertCreateAccount(CORRECT_BODY_XRP, poolName, walletName, Status.Ok)
-    val addresses = parse[Seq[FreshAddressView]](assertGetFreshAddresses(poolName, walletName, index = 0, Status.Ok))
-    assert(addresses.nonEmpty)
-    info(s"Here are addresses : $addresses")
-    assertSyncAccount(poolName, walletName, 0)
-    val operations = parse[Map[String, JsonNode]](assertGetAccountOps(poolName, walletName, 0, OperationQueryParams(None, None, 1000, 0), Status.Ok))
-    assert(operations.nonEmpty)
-    deletePool(poolName)
-  }
-
   private val CORRECT_BODY_ETH =
     """{""" +
       """"account_index": 0,""" +

--- a/src/it/scala/co/ledger/wallet/daemon/api/XRPAccountsApiTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/api/XRPAccountsApiTest.scala
@@ -1,0 +1,107 @@
+package co.ledger.wallet.daemon.api
+
+import co.ledger.wallet.daemon.clients.ClientFactory
+import co.ledger.wallet.daemon.controllers.TransactionsController.{CreateXRPTransactionRequest, XRPSendToRequest}
+import co.ledger.wallet.daemon.models.FreshAddressView
+import co.ledger.wallet.daemon.models.coins.UnsignedRippleTransactionView
+import co.ledger.wallet.daemon.services.OperationQueryParams
+import co.ledger.wallet.daemon.utils.APIFeatureTest
+import com.fasterxml.jackson.databind.JsonNode
+import com.twitter.finagle.http.Status
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class XRPAccountsApiTest extends APIFeatureTest {
+
+  val poolName = "op_pool"
+
+  override def beforeAll(): Unit = {
+    createPool(poolName)
+  }
+
+  override def afterAll(): Unit = {
+    deletePool(poolName)
+  }
+
+  private val CORRECT_BODY_XRP =
+    """{""" +
+      """"account_index": 0,""" +
+      """"derivations": [""" +
+      """{""" +
+      """"owner": "main",""" +
+      """"path": "44'/144'/2'",""" +
+      """"pub_key": "03432A07E9AE9D557F160D9B1856F909E421B399E12673EEE0F4045F4F7BA151CF",""" +
+      """"chain_code": "5D958E80B0373FA505B95C1DD175B0588205D1620C56F7247B028EBCB0FB5032"""" +
+      """}""" +
+      """]""" +
+      """}"""
+
+  test("Create XRP account") {
+    val walletName = "xrpWalletAccountCreation"
+    assertWalletCreation(poolName, walletName, "ripple", Status.Ok)
+    assertCreateAccount(CORRECT_BODY_XRP, poolName, walletName, Status.Ok)
+    val addresses = parse[Seq[FreshAddressView]](assertGetFreshAddresses(poolName, walletName, index = 0, Status.Ok))
+    assert(addresses.nonEmpty)
+    info(s"Here are addresses : $addresses")
+    assertSyncAccount(poolName, walletName, 0)
+    val operations = parse[Map[String, JsonNode]](assertGetAccountOps(poolName, walletName, 0, OperationQueryParams(None, None, 1000, 0), Status.Ok))
+    assert(operations.nonEmpty)
+  }
+
+  test("Create XRP Transaction") {
+    val walletName = "xrpWalletForCreateTX"
+    assertWalletCreation(poolName, walletName, "ripple", Status.Ok)
+    assertCreateAccount(CORRECT_BODY_XRP, poolName, walletName, Status.Ok)
+    val addresses = parse[Seq[FreshAddressView]](assertGetFreshAddresses(poolName, walletName, index = 0, Status.Ok))
+    assert(addresses.nonEmpty)
+    info(s"Here are addresses : $addresses")
+    assertSyncAccount(poolName, walletName, 0)
+    val operations = parse[Map[String, JsonNode]](assertGetAccountOps(poolName, walletName, 0, OperationQueryParams(None, None, 1000, 0), Status.Ok))
+    assert(operations.nonEmpty)
+
+    val networkFee = Await.result(ClientFactory.apiClient.getFeesRipple, 10.second)
+    info(s"Network fee = $networkFee")
+    // No fees, no feesLevel provided
+    val sendToAddresses = List(addresses.head.address).map(add => XRPSendToRequest("10000", add))
+
+    val txBadRequest = CreateXRPTransactionRequest(sendToAddresses, None, None, None, List.empty, None)
+    val txBadRequestJson = server.mapper.objectMapper.writeValueAsString(txBadRequest)
+    // Neither fees nor fees_level has been provided, expect failure due to MethodValidation check
+    assertCreateTransaction(txBadRequestJson, poolName, walletName, 0, Status.BadRequest)
+
+    // Check No fees amount provided with fee_level provided
+    val txRequest = CreateXRPTransactionRequest(sendToAddresses, None, None, Some("FAST"), List.empty, None)
+    val txRequestJson = server.mapper.objectMapper.writeValueAsString(txRequest)
+    val transactionView = parse[UnsignedRippleTransactionView](assertCreateTransaction(txRequestJson, poolName, walletName, 0, Status.Ok))
+    info(s"Here is transaction view : $transactionView")
+    assert(transactionView.receiver == sendToAddresses.head.address)
+    assert(transactionView.sender == sendToAddresses.head.address)
+
+    // Check even if fees are higher or lower than networks one, they override network fees
+    val highMaxFee: Int = 1234567
+    val lowMaxFee: Int = 1
+    val txRequestSlow = CreateXRPTransactionRequest(sendToAddresses, None,
+      Some(String.valueOf(highMaxFee)), Some("SLOW"), List.empty, None)
+    val txRequestJsonSlow = server.mapper.objectMapper.writeValueAsString(txRequestSlow)
+    val transactionViewSlow = parse[UnsignedRippleTransactionView](assertCreateTransaction(txRequestJsonSlow, poolName, walletName, 0, Status.Ok))
+    info(s"Here is transaction view : $transactionViewSlow")
+    assert(BigInt(transactionViewSlow.fees) == BigInt(highMaxFee))
+
+    val txRequestFast = CreateXRPTransactionRequest(sendToAddresses, None,
+      Some(String.valueOf(lowMaxFee)), Some("FAST"), List.empty, None)
+    val txRequestJsonFast = server.mapper.objectMapper.writeValueAsString(txRequestFast)
+    val transactionViewFast = parse[UnsignedRippleTransactionView](assertCreateTransaction(txRequestJsonFast, poolName, walletName, 0, Status.Ok))
+    info(s"Here is transaction view : $transactionViewFast")
+    assert(BigInt(transactionViewFast.fees) == BigInt(lowMaxFee))
+
+  }
+
+
+  def transactionRequest(poolName: String, walletName: String, accountIdx: Int, xrpTransacRequest: CreateXRPTransactionRequest): String = {
+    val txInfo = server.mapper.objectMapper.writeValueAsString(xrpTransacRequest)
+    s"""{"pool_name:"$poolName","$walletName":"xrpWallet","account_index":$accountIdx, $txInfo"""
+  }
+
+}
+

--- a/src/it/scala/co/ledger/wallet/daemon/clients/ApiClientTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/clients/ApiClientTest.scala
@@ -4,13 +4,13 @@ import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 class ApiClientTest extends AssertionsForJUnit {
   private[this] val apiClient = ClientFactory.apiClient
 
   @Test def verifyQueryBTCFee(): Unit = {
-    val feeInfo = Await.result(apiClient.getFees("bitcoin"), Duration.Inf)
+    val feeInfo = Await.result(apiClient.getFees("bitcoin"), 10.seconds)
     assert(feeInfo.fast >= feeInfo.normal)
     assert(feeInfo.normal >= feeInfo.slow)
     assert(feeInfo.fast >= feeInfo.slow)

--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -318,4 +318,15 @@ explorer = {
   }
 }
 
+ethereum = {
+  feesfactor = {
+      slow = 0.75
+      slow = ${?ETH_SLOW_FEE_FACTOR}
+      normal = 1.0
+      normal = ${?ETH_NORMAL_FEE_FACTOR}
+      fast = 1.25
+      fast = ${?ETH_FAST_FEE_FACTOR}
+  }
+}
+
 native_segwit_currencies = ["bitcoin", "bitcoin_testnet", "litecoin", "qtum"]

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
@@ -4,9 +4,10 @@ import java.net.URL
 
 import co.ledger.core
 import co.ledger.wallet.daemon.configurations.DaemonConfiguration
+import co.ledger.wallet.daemon.configurations.DaemonConfiguration._
 import co.ledger.wallet.daemon.models.FeeMethod
-import co.ledger.wallet.daemon.utils.{HexUtils, NetUtils}
 import co.ledger.wallet.daemon.utils.Utils._
+import co.ledger.wallet.daemon.utils.{HexUtils, NetUtils}
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.twitter.finagle.http.{Method, Request}
 import com.twitter.finatra.json.FinatraObjectMapper
@@ -45,7 +46,7 @@ class ApiClient(implicit val ec: ExecutionContext) extends Logging {
       mapper.objectMapper.readTree(response.contentString)
         .fields.asScala.filter(_.getKey forall Character.isDigit)
         .map(_.getValue.asInt).toList.sorted.map(BigInt.apply) match {
-        case low :: medium :: high :: Nil => FeeInfo(high, medium, low)
+        case low :: medium :: high :: Nil => BtcFeeInfo(high, medium, low)
         case _ =>
           warn(s"Failed to retrieve fees from explorer, falling back on default fees.")
           defaultBTCFeeInfo
@@ -61,10 +62,10 @@ class ApiClient(implicit val ec: ExecutionContext) extends Logging {
       throw new UnsupportedOperationException(s"Currency not supported '$currencyName'")).path
 
 
-  def getFeesRipple: Future[BigInt] = {
+  def getFeesRipple: Future[RippleFeeInfo] = {
     val serviceUrl: CurrencyServiceURL = currencyServiceURLFor("ripple")
     val request = Request(Method.Post, "/").host(serviceUrl.url.getHost)
-    val body = "{\"method\":\"server_state\",\"params\":[{}]}"
+    val body = "{\"method\":\"fee\",\"params\":[{}]}"
     request.setContentString(body)
     request.setContentType("application/json")
 
@@ -74,24 +75,25 @@ class ApiClient(implicit val ec: ExecutionContext) extends Logging {
       val result = json.flatMap { j =>
         for {
           rippleResult <- j.hcursor.get[Json]("result")
-          rippleState <- rippleResult.hcursor.get[Json]("state")
-          rippleValidatedLedger <- rippleState.hcursor.get[Json]("validated_ledger")
-          baseFee <- rippleValidatedLedger.hcursor.get[Double]("base_fee")
-          loadFactor <- rippleState.hcursor.get[Double]("load_factor")
-          loadBase <- rippleState.hcursor.get[Double]("load_base")
+          drops <- rippleResult.hcursor.get[Json]("drops")
+          openLedgerFee <- drops.hcursor.get[Int]("open_ledger_fee")
+          baseFee <- drops.hcursor.get[Int]("base_fee")
+          levels <- rippleResult.hcursor.get[Json]("levels")
+          loadFactor <- levels.hcursor.get[Int]("open_ledger_level")
+          loadBase <- levels.hcursor.get[Int]("reference_level")
         } yield {
-          info(s"Query rippled server_state: baseFee=$baseFee loadFactor:$loadFactor loadBase=$loadBase")
-          BigInt(((baseFee * loadFactor) / loadBase).toInt)
+          info(s"Query rippled fee method: baseFee=$baseFee loadFactor:$loadFactor loadBase=$loadBase, openLedgerFee=$openLedgerFee")
+          RippleFeeInfo(baseFee, loadFactor, loadBase, openLedgerFee)
         }
       }
 
       result.getOrElse {
-        info(s"Failed to query server_state method of ripple daemon: " +
-          s"uri=${serviceUrl.url.getHost} request=${request.contentString} response=${response.contentString}")
-        defaultXRPFees
+        info(s"Failed to query fee method of ripple daemon: " +
+          s"uri=${serviceUrl.url.getHost} request=${request.contentString} response=${response.contentString}, using default XRP fees $defaultXRPFeesInfo")
+        defaultXRPFeesInfo
       }
     }
-    }.asScala()
+  }.asScala()
 
   def getGasLimit(currency: core.Currency, recipient: String, source: Option[String] = None, inputData: Option[Array[Byte]] = None): Future[BigInt] = {
     import io.circe.syntax._
@@ -117,23 +119,23 @@ class ApiClient(implicit val ec: ExecutionContext) extends Logging {
     }.asScala()
   }
 
-  def getGasPrice(currencyName: String): Future[BigInt] = {
+  def getGasPrice(currencyName: String): Future[EthFeeInfo] = {
     val serviceUrl: CurrencyServiceURL = currencyServiceURLFor(currencyName)
     val path = feesPathForCurrency(currencyName)
     val request = Request(Method.Get, path).host(serviceUrl.url.getHost)
     feeServices.execute(serviceUrl.url, request).map { response =>
-      mapper.parse[GasPrice](response).price
+      EthFeeInfo(mapper.parse[GasPrice](response))
     }.asScala()
   }
 
   private val defaultGasLimit =
     BigInt(200000)
-  private val defaultXRPFees =
+  private val defaultXRPFeesInfo = RippleFeeInfo(10, 256, 256, 10)
     BigInt(10)
 
   // {"2":18281,"3":12241,"6":10709,"last_updated":1580478904}
-  private val defaultBTCFeeInfo =
-    FeeInfo(18281, 12241, 10709)
+  private val defaultBTCFeeInfo: BtcFeeInfo =
+    BtcFeeInfo(18281, 12241, 10709)
 }
 
 object ApiClient {
@@ -141,11 +143,39 @@ object ApiClient {
   val feeServices = new ScalaHttpClientPool()
   val fallbackServices = new ScalaHttpClientPool()
 
-  case class FeeInfo(fast: BigInt, normal: BigInt, slow: BigInt) {
+  trait FeeInfo {
+    def getAmount(feeMethod: FeeMethod): BigInt
+
+    def slow: BigInt = getAmount(FeeMethod.SLOW)
+
+    def normal: BigInt = getAmount(FeeMethod.NORMAL)
+
+    def fast: BigInt = getAmount(FeeMethod.FAST)
+  }
+
+  case class BtcFeeInfo(fastFee: BigInt, normalFee: BigInt, slowFee: BigInt) extends FeeInfo {
     def getAmount(feeMethod: FeeMethod): BigInt = feeMethod match {
-      case FeeMethod.FAST => fast / 1000
-      case FeeMethod.NORMAL => normal / 1000
-      case FeeMethod.SLOW => slow / 1000
+      case FeeMethod.FAST => fastFee / 1000
+      case FeeMethod.NORMAL => normalFee / 1000
+      case FeeMethod.SLOW => slowFee / 1000
+    }
+  }
+
+  case class RippleFeeInfo(baseFee: Int, loadFactor: Int, loadBase: Int, openLedgerCost: Int) extends FeeInfo {
+    val loadCoast: Int = ((baseFee * loadFactor).toDouble / loadBase.toDouble).intValue()
+
+    def getAmount(feeMethod: FeeMethod): BigInt = feeMethod match {
+      case FeeMethod.SLOW => BigInt(baseFee)
+      case FeeMethod.NORMAL => BigInt(baseFee + loadCoast)
+      case FeeMethod.FAST => BigInt((baseFee + (loadCoast + openLedgerCost) * 1.5D).toInt)
+    }
+  }
+
+  case class EthFeeInfo(gasPrice: GasPrice) extends FeeInfo {
+    def getAmount(feeMethod: FeeMethod): BigInt = feeMethod match {
+      case FeeMethod.SLOW => (BigDecimal(gasPrice.price) * ETH_SLOW_FEES_FACTOR).toBigInt
+      case FeeMethod.NORMAL => (BigDecimal(gasPrice.price) * ETH_NORMAL_FEES_FACTOR).toBigInt
+      case FeeMethod.FAST => (BigDecimal(gasPrice.price) * ETH_FAST_FEES_FACTOR).toBigInt
     }
   }
 

--- a/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
@@ -228,12 +228,16 @@ object DaemonConfiguration extends Logging {
       currency -> FeesPath(path)
     }.toMap
 
-
     val ws = explorer.getObject("ws").unwrapped().asScala.toMap.mapValues(_.toString)
     ExplorerConfig(
       ApiConfig(fallbackTimeout, paths, proxyUseMap, fees),
       ClientConnectionConfig(connectionPoolSize, retryBackoffDelta, connectionPoolTtl, retryTtl, retryMin, retryPercent), ws)
   }
+
+
+  val ETH_SLOW_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.slow")).getOrElse(0.75)
+  val ETH_NORMAL_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.normal")).getOrElse(1.0)
+  val ETH_FAST_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.fast")).getOrElse(1.25)
 
   val rippleLastLedgerSequenceOffset: Int = {
     if (config.hasPath("ripple_last_ledger_sequence_offset")) {

--- a/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/TransactionsController.scala
@@ -115,6 +115,7 @@ object TransactionsController {
                                          amount: String,
                                          gas_limit: Option[String],
                                          gas_price: Option[String],
+                                         fees_level: Option[String],
                                          contract: Option[String]
                                         ) extends CreateTransactionRequest {
     def amountValue: BigInt = BigInt(amount)
@@ -123,7 +124,10 @@ object TransactionsController {
 
     def gasPriceValue: Option[BigInt] = gas_price.map(BigInt(_))
 
-    override def transactionInfo: TransactionInfo = ETHTransactionInfo(recipient, amountValue, gasLimitValue, gasPriceValue, contract)
+    override def transactionInfo: TransactionInfo = ETHTransactionInfo(recipient, amountValue, gasLimitValue, gasPriceValue, fees_level, contract)
+
+    @MethodValidation
+    def validateFees: ValidationResult = CommonMethodValidations.validateFees(gasPriceValue, fees_level)
   }
 
   case class CreateBTCTransactionRequest(recipient: String,
@@ -156,6 +160,7 @@ object TransactionsController {
   case class CreateXRPTransactionRequest(send_to: List[XRPSendToRequest], // Send funds to the given address.
                                          wipe_to: Option[String], // Send all available funds to the given address.
                                          fees: Option[String], // Fees (in drop) the originator is willing to pay
+                                         fees_level: Option[String],
                                          memos: List[RippleLikeMemo], // Memos to add for this transaction
                                          destination_tag: Option[Long] // An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
                                         ) extends CreateTransactionRequest {
@@ -163,23 +168,40 @@ object TransactionsController {
 
     def feesValue: Option[BigInt] = fees.map(BigInt(_))
 
-    override def transactionInfo: TransactionInfo = XRPTransactionInfo(sendToValue, wipe_to, feesValue: Option[BigInt], memos, destination_tag)
+    override def transactionInfo: TransactionInfo = XRPTransactionInfo(sendToValue, wipe_to, feesValue: Option[BigInt], fees_level: Option[String], memos, destination_tag)
+
+    @MethodValidation
+    def validateFees: ValidationResult = CommonMethodValidations.validateFees(feesValue, fees_level)
   }
 
   trait TransactionInfo
 
   case class BTCTransactionInfo(recipient: String,
-                                feeAmount: Option[BigInt],
-                                feeLevel: Option[String],
+                                fees: Option[BigInt],
+                                feesLevel: Option[String],
                                 amount: BigInt,
                                 pickingStrategy: BitcoinLikePickingStrategy,
                                 excludeUtxos: Map[String, Int],
                                 partialTx: Option[Boolean]) extends TransactionInfo {
-    lazy val feeMethod: Option[FeeMethod] = feeLevel.map { level => FeeMethod.from(level) }
+    lazy val feesSpeedLevel: Option[FeeMethod] = feesLevel.map { feesLevel => FeeMethod.from(feesLevel) }
   }
 
-  case class ETHTransactionInfo(recipient: String, amount: BigInt, gasLimit: Option[BigInt], gasPrice: Option[BigInt], contract: Option[String]) extends TransactionInfo
+  case class ETHTransactionInfo(recipient: String,
+                                amount: BigInt,
+                                gasLimit: Option[BigInt],
+                                gasPrice: Option[BigInt],
+                                feesLevel: Option[String],
+                                contract: Option[String]) extends TransactionInfo {
+    lazy val feesSpeedLevel: Option[FeeMethod] = feesLevel.map { feesLevel => FeeMethod.from(feesLevel) }
+  }
 
-  case class XRPTransactionInfo(sendTo: List[XRPSendTo], wipeTo: Option[String], fees: Option[BigInt], memos: List[RippleLikeMemo], destinationTag: Option[Long]) extends TransactionInfo
+  case class XRPTransactionInfo(sendTo: List[XRPSendTo],
+                                wipeTo: Option[String],
+                                fees: Option[BigInt],
+                                feesLevel: Option[String],
+                                memos: List[RippleLikeMemo],
+                                destinationTag: Option[Long]) extends TransactionInfo {
+    lazy val feesSpeedLevel: Option[FeeMethod] = feesLevel.map { feesLevel => FeeMethod.from(feesLevel) }
+  }
 
 }

--- a/src/main/scala/co/ledger/wallet/daemon/controllers/requests/CommonMethodValidations.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/controllers/requests/CommonMethodValidations.scala
@@ -21,7 +21,7 @@ object CommonMethodValidations {
   def validateFees(feeAmount: Option[BigInt], feeLevel: Option[String]): ValidationResult = {
     ValidationResult.validate(feeAmount.isDefined
       || (feeLevel.isDefined && FeeMethod.isValid(feeLevel.get)),
-      "fee_amount or fee_level must be defined, fee_level must be one of 'FAST', 'NORMAL', 'SLOW'")
+      "fee_amount or fee_level must be defined, fees_level must be one of 'FAST', 'NORMAL', 'SLOW'")
   }
 
   def validateTimePeriod(timeInterval: String): ValidationResult = {

--- a/src/main/scala/co/ledger/wallet/daemon/services/TransactionsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/TransactionsService.scala
@@ -28,6 +28,7 @@ class TransactionsService @Inject()(defaultDaemonCache: DefaultDaemonCache, mess
           case WalletType.RIPPLE => Right(messageBodyManager.read[CreateXRPTransactionRequest](request))
           case w => Left(CurrencyNotFoundException(w.name()))
         }
+
         transactionInfoEither match {
           case Right(transactionInfo) =>
             account.createTransaction(transactionInfo.transactionInfo, wallet.getCurrency)


### PR DESCRIPTION
Harmonization of Create transaction payloads

- All BTC/ETH/XRP create transaction payload has `fees_level` field which is an enum value {`SLOW`, `NORMAL`, `FAST`}. 
- User can **override** fees by setting `fees` field on payload.
- Validation methods are ensuring that at least one of them is setup and will reject any request without at least fees or fees_level filled.
 
______________________

The fees level defines the amount of fees used according the current network load : 

**BTC** : 
- _SLOW_ : returned by explorer, amount to be included in the nexts 6 blocks 
- _NORMAL_ : returned by explorer, amount to be included in the nexts 3 blocks 
- _FAST_ : returned by explorer, amount to be included in the nexts 2 blocks 

**ETH** : Network `Gas Price * ETH_XXX_FEES_FACTOR` (configurable)
- _SLOW_ : Network Gas Price * 0.75 (Default conf value)
- _NORMAL_ : Network Gas Price * 1 (Default conf value)
- _FAST_ : Network Gas Price * 1.25 (Default conf value)

**XRP** : Note that `load coast`, `open ledger coast` and `base fee` are defined by the network 
- _SLOW_ : base fee
- _NORMAL_ : Base fee + load coast 
- _FAST_ :  base fee + (loadCoast + openLedgerCost) * 1.5

