### PR TITLE
BACK-708 : Add Qtum support on Ledger Wallet Daemon

### DIFF
--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -287,6 +287,11 @@ explorer = {
         path = ${?FEES_ZEC_PATH}
     }
     {
+        currency = "qtum"
+        path = "/blockchain/v2/qtum/fees"
+        path = ${?FEES_QTUM_PATH}
+    }
+    {
         currency = "ethereum"
         path = "/blockchain/v3/eth/fees"
         path = ${?FEES_ETH_PATH}


### PR DESCRIPTION
This PR adds the "GET fee" endpoint for qtum on wallet daemon in order to be able to create
Qtum transactions on ledger vault