### PR TITLE
publish docker image to githubpkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,3 +133,19 @@ workflows:
                 - /coin\/.*/
             tags:
               only: /.*/
+      - docker/publish_image:
+          context: githubpkg
+          requires:
+            - docker/test_image
+          filters:
+            branches:
+              only:
+                - master
+                - master-drop2
+                - develop
+                - develop-drop2
+                - release_candidate
+                - release_candidate_drop2
+                - /coin\/.*/
+            tags:
+              only: /.*/


### PR DESCRIPTION
our dockerhub account is full, we will migrate to githubpkg
This patch publish the image on both registry

In order to work, an admin should go to
https://github.com/LedgerHQ/ledger-wallet-daemon/settings/access
and add "ldg-github-ci" with role "Write"