### PR TITLE
Back 866 wrong height on unconfirmed utxos

### DIFF
--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -83,38 +83,38 @@ explorer = {
     paths = [
       {
         currency = default
-        host = "https://api.ledgerwallet.com"
-        port = 443
+        host = "http://explorers.api-01.vault.ledger-stg.com"
+        port = 80
         proxyuse = true
         proxyuse = ${?WALLET_DEFAULT_EXPLORER_PROXYUSE}
       }
       {
         currency = bitcoin
-        host = "https://api.ledgerwallet.com"
+        host = "http://explorers.api-01.vault.ledger-stg.com"
         host = ${?WALLET_BTC_EXPLORER_ENDPOINT}
-        port = 443
+        port = 80
         port = ${?WALLET_BTC_EXPLORER_PORT}
-        explorer_version = "v2"
+        explorer_version = "v3"
         explorer_version = ${?WALLET_BTC_EXPLORER_VERSION}
         proxyuse = true
         proxyuse = ${?WALLET_BTC_EXPLORER_PROXYUSE}
       }
       {
         currency = bitcoin_testnet
-        host = "https://explorers.api.live.ledger.com"
+        host = "http://explorers.api-01.vault.ledger-stg.com"
         host = ${?WALLET_BTC_TESTNET_EXPLORER_ENDPOINT}
-        port = 443
+        port = 80
         port = ${?WALLET_BTC_TESTNET_EXPLORER_PORT}
-        explorer_version = "v2"
+        explorer_version = "v3"
         explorer_version = ${?WALLET_BTC_TESTNET_EXPLORER_VERSION}
         proxyuse = true
         proxyuse = ${?WALLET_BTC_TESTNET_EXPLORER_PROXYUSE}
       }
       {
         currency = ethereum
-        host = "https://explorers.api.live.ledger.com"
+        host = "http://explorers.api-01.vault.ledger-stg.com/"
         host = ${?WALLET_ETH_EXPLORER_ENDPOINT}
-        port = 443
+        port = 80
         port = ${?WALLET_ETH_EXPLORER_PORT}
         explorer_version = "v3"
         explorer_version = ${?WALLET_ETH_EXPLORER_VERSION}
@@ -136,9 +136,9 @@ explorer = {
       }
       {
         currency = ethereum_ropsten
-        host = "https://explorers.api.live.ledger.com"
+        host = "http://explorers.api-01.vault.ledger-stg.com/"
         host = ${?WALLET_ETH_ROPSTEN_EXPLORER_ENDPOINT}
-        port = 443
+        port = 80
         port = ${?WALLET_ETH_ROPSTEN_EXPLORER_PORT}
         explorer_version = "v3"
         explorer_version = ${?WALLET_ETH_ROPSTEN_EXPLORER_VERSION}
@@ -167,82 +167,82 @@ explorer = {
     fees = [
       {
         currency = "bitcoin"
-        path = "/blockchain/v2/btc/fees"
+        path = "/blockchain/v3/btc/fees"
         path = ${?FEES_BTC_PATH}
       }
       {
         currency = "bitcoin_testnet"
-        path = "/blockchain/v2/btc_testnet/fees"
+        path = "/blockchain/v3/btc_testnet/fees"
         path = ${?FEES_BTC_TESTNET_PATH}
       }
       {
         currency = "dogecoin"
-        path = "/blockchain/v2/doge/fees"
+        path = "/blockchain/v3/doge/fees"
         path = ${?FEES_DOGE_PATH}
       }
       {
         currency = "litecoin"
-        path = "/blockchain/v2/ltc/fees"
+        path = "/blockchain/v3/ltc/fees"
         path = ${?FEES_LTC_PATH}
       }
       {
         currency = "dash"
-        path = "/blockchain/v2/dash/fees"
+        path = "/blockchain/v3/dash/fees"
         path = ${?FEES_DASH_PATH}
       }
       {
         currency = "komodo"
-        path = "/blockchain/v2/kmd/fees"
+        path = "/blockchain/v3/kmd/fees"
         path = ${?FEES_KMD_PATH}
       }
       {
         currency = "pivx"
-        path = "/blockchain/v2/pivx/fees"
+        path = "/blockchain/v3/pivx/fees"
         path = ${?FEES_PIVX_PATH}
       }
       {
         currency = "viacoin"
-        path = "/blockchain/v2/via/fees"
+        path = "/blockchain/v3/via/fees"
         path = ${?FEES_VIA_PATH}
       }
       {
         currency = "vertcoin"
-        path = "/blockchain/v2/vtc/fees"
+        path = "/blockchain/v3/vtc/fees"
         path = ${?FEES_VTC_PATH}
       }
       {
         currency = "digibyte"
-        path = "/blockchain/v2/dgb/fees"
+        path = "/blockchain/v3/dgb/fees"
         path = ${?FEES_DGB_PATH}
       }
       {
         currency = "bitcoin_cash"
-        path = "/blockchain/v2/abc/fees"
+        path = "/blockchain/v3/abc/fees"
         path = ${?FEES_ABC_PATH}
       }
       {
         currency = "poswallet"
-        path = "/blockchain/v2/posw/fees"
+        path = "/blockchain/v3/posw/fees"
         path = ${?FEES_POSW_PATH}
       }
       {
         currency = "stratis"
-        path = "/blockchain/v2/strat/fees"
+        path = "/blockchain/v3/strat/fees"
         path = ${?FEES_STRAT_PATH}
       }
       {
         currency = "peercoin"
-        path = "/blockchain/v2/ppc/fees"
+        path = "/blockchain/v3/ppc/fees"
         path = ${?FEES_PPC_PATH}
       }
       {
         currency = "bitcoin_gold"
-        path = "/blockchain/v2/btg/fees"
+        path = "/blockchain/v3/btg/fees"
         path = ${?FEES_BTG_PATH}
       }
       {
         currency = "zcash"
-        path = "/blockchain/v2/zec/fees"
+        path = "/blockchain/v3/zec/fees"
         path = ${?FEES_ZEC_PATH}
       }
       {
@@ -264,7 +264,7 @@ explorer = {
   }
 
   ws {
-    default = "ws://ws.ledgerwallet.com/blockchain/v2/{}/ws"
+    default = "ws://ws.ledgerwallet.com/blockchain/v3/{}/ws"
     // possible keys: bitcoin, bitcoin_testnet, bitcoin_cash,
     // bitcoin_gold, zcash, zencash, litecoin, peercoin, digibyte,
     // hcash, qtum, stealthcoin, vertcoin, viacoin, dash, dogecoin,

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ApiClient.scala
@@ -128,10 +128,8 @@ class ApiClient(implicit val ec: ExecutionContext) extends Logging {
     }.asScala()
   }
 
-  private val defaultGasLimit =
-    BigInt(200000)
+  private val defaultGasLimit = BigInt(200000)
   private val defaultXRPFeesInfo = RippleFeeInfo(10, 256, 256, 10)
-    BigInt(10)
 
   // {"2":18281,"3":12241,"6":10709,"last_updated":1580478904}
   private val defaultBTCFeeInfo: BtcFeeInfo =

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -85,13 +85,9 @@ class AccountsService @Inject()(daemonCache: DaemonCache) extends DaemonService 
   def synchronizeAccount(accountInfo: AccountInfo): Future[Seq[SynchronizationResult]] =
     daemonCache.withAccount(accountInfo)(_.sync(accountInfo.poolName, accountInfo.walletName).map(Seq(_)))
 
-  def getAccount(accountInfo: AccountInfo): Future[Option[core.Account]] = {
-    daemonCache.getAccount(accountInfo: AccountInfo)
-  }
+  def getAccount(accountInfo: AccountInfo): Future[Option[core.Account]] = daemonCache.getAccount(accountInfo: AccountInfo)
 
-  def getBalance(contract: Option[String], accountInfo: AccountInfo): Future[BigInt] =
-    balanceCache.get(CacheKey(accountInfo, contract))
-
+  def getBalance(contract: Option[String], accountInfo: AccountInfo): Future[BigInt] = balanceCache.get(CacheKey(accountInfo, contract))
 
   def getUtxo(accountInfo: AccountInfo, offset: Int, batch: Int): Future[(List[UTXOView], Int)] =
     daemonCache.withAccountAndWallet(accountInfo) { (account, wallet) =>
@@ -99,12 +95,14 @@ class AccountsService @Inject()(daemonCache: DaemonCache) extends DaemonService 
         lastBlockHeight <- wallet.lastBlockHeight
         count <- account.getUtxoCount()
         utxos <- account.getUtxo(offset, batch).map(_.map(output => {
+          val confirmations: Long =
+            if (output.getBlockHeight >= 0) lastBlockHeight - output.getBlockHeight else output.getBlockHeight
           UTXOView(
             output.getTransactionHash,
             output.getOutputIndex,
             output.getAddress,
             output.getBlockHeight,
-            lastBlockHeight - output.getBlockHeight,
+            confirmations,
             output.getValue.toBigInt.asScala)
         }))
       } yield (utxos, count)


### PR DESCRIPTION
Libcore is returning -1 for unconfirmed utxos. Today we are not handling properly this property and this lead to wrong confirmation number computation on WD

So we keep as it when block-height is negative, otherwise we compute confirmations with `latestWalletKnownBlockHeight - utxoBlockHeight`

