### PR TITLE
BACK-883 : provide new endpoint to get the n latests operations of an…

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -467,7 +467,7 @@ object Account extends Logging {
   }
 
   def latestOperations(latests: Int, query: OperationQuery)(implicit ec: ExecutionContext): Future[Seq[core.Operation]] = {
-    query.addOrder(OperationOrderKey.DATE, true).offset(0).limit(latests).partial().execute().map { operations => operations.asScala.toList }
+    query.addOrder(OperationOrderKey.DATE, true).offset(0).limit(latests).complete().execute().map { operations => operations.asScala.toList }
   }
 
   def balances(start: String, end: String, timePeriod: core.TimePeriod, a: core.Account)(implicit ec: ExecutionContext): Future[List[scala.BigInt]] = {

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -105,6 +105,9 @@ object Account extends Logging {
     def operations(offset: Int, batch: Int, fullOp: Int)(implicit ec: ExecutionContext): Future[Seq[core.Operation]] =
       Account.operations(offset, batch, fullOp, a.queryOperations())
 
+    def latestOperations(latests: Int)(implicit ec: ExecutionContext): Future[Seq[core.Operation]] =
+      Account.latestOperations(latests, a.queryOperations())
+
     def freshAddresses(implicit ec: ExecutionContext): Future[Seq[core.Address]] =
       Account.freshAddresses(a)
 
@@ -288,9 +291,9 @@ object Account extends Logging {
         case None => ClientFactory.apiClient.getFees(c.getName).map(f => f.getAmount(ti.feesSpeedLevel.getOrElse(FeeMethod.NORMAL)))
       }
       builder = a.asBitcoinLikeAccount().buildTransaction(partial)
-          .sendToAddress(c.convertAmount(ti.amount), ti.recipient)
-          .setFeesPerByte(c.convertAmount(feesPerByte))
-          .pickInputs(ti.pickingStrategy, UnsignedInteger.MAX_VALUE.intValue())
+        .sendToAddress(c.convertAmount(ti.amount), ti.recipient)
+        .setFeesPerByte(c.convertAmount(feesPerByte))
+        .pickInputs(ti.pickingStrategy, UnsignedInteger.MAX_VALUE.intValue())
       _ = for ((address, index) <- ti.excludeUtxos) builder.excludeUtxo(address, index)
       tx <- builder.build()
       v <- Bitcoin.newUnsignedTransactionView(tx, feesPerByte, partial)
@@ -461,6 +464,10 @@ object Account extends Logging {
     } else {
       query.addOrder(OperationOrderKey.DATE, true).offset(offset).limit(batch).partial().execute()
     }).map { operations => operations.asScala.toList }
+  }
+
+  def latestOperations(latests: Int, query: OperationQuery)(implicit ec: ExecutionContext): Future[Seq[core.Operation]] = {
+    query.addOrder(OperationOrderKey.DATE, true).offset(0).limit(latests).partial().execute().map { operations => operations.asScala.toList }
   }
 
   def balances(start: String, end: String, timePeriod: core.TimePeriod, a: core.Account)(implicit ec: ExecutionContext): Future[List[scala.BigInt]] = {

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -248,6 +248,15 @@ class AccountsService @Inject()(daemonCache: DaemonCache) extends DaemonService 
         }
     }
   }
+  def latestOperations(accountInfo: AccountInfo, latests: Int): Future[Seq[OperationView]] = {
+    daemonCache.withAccountAndWallet(accountInfo) {
+      case (account, wallet) =>
+        account.latestOperations(latests)
+          .flatMap(ops => Future.sequence(
+            ops.map(Operations.getView(_, wallet, account)))
+        )
+    }
+  }
 
   def accountOperation(uid: String, fullOp: Int, accountInfo: AccountInfo): Future[Option[OperationView]] =
     daemonCache.withAccountAndWallet(accountInfo) {


### PR DESCRIPTION
Expose a new endpoint for retrieving latests operations : 
`/pool/<poolname>/wallets/<walletName>/accounts/<AccIdx>/operations/latests`
You can optionally provide a length (default is 10)

Exemple : 
`/pool/<poolname>/wallets/<walletName>/accounts/<AccIdx>/operations/latests?length=15`

Behind the scene we are ordering operations by Date, descending


**HODL** : Need tests + ERC20 support