### PR TITLE
BACK-831 : Configurable factor for smart contract gaslimit

### DIFF
--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -324,6 +324,8 @@ ethereum = {
       fast = 1.25
       fast = ${?ETH_FAST_FEE_FACTOR}
   }
+  gaslimitfactor = 2
+  gaslimitfactor = ${?ETH_GAS_LIMIT_FACTOR}
 }
 
 native_segwit_currencies = ["bitcoin", "bitcoin_testnet", "litecoin", "qtum"]

--- a/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/configurations/DaemonConfiguration.scala
@@ -227,6 +227,13 @@ object DaemonConfiguration extends Logging {
   val ETH_SLOW_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.slow")).getOrElse(0.75)
   val ETH_NORMAL_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.normal")).getOrElse(1.0)
   val ETH_FAST_FEES_FACTOR: Double = Try(config.getDouble("ethereum.feesfactor.fast")).getOrElse(1.25)
+  /**
+    * We are facing frequent gas limit too low issue on smart contract interactions
+    * (see : https://ledgerhq.atlassian.net/browse/BACK-831)
+    * This is probably due to rounded value from RPC node to our explorers due to conversion issue.
+    * We expose here ability to configure factor for estimated gas limit amplification
+    */
+  val ETH_SMART_CONTRACT_GAS_LIMIT_FACTOR: Double = Try(config.getDouble("ethereum.gaslimitfactor")).getOrElse(2)
 
   val rippleLastLedgerSequenceOffset: Int = {
     if (config.hasPath("ripple_last_ledger_sequence_offset")) {

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -20,6 +20,7 @@ import co.ledger.wallet.daemon.models.coins._
 import co.ledger.wallet.daemon.schedulers.observers.{SynchronizationEventReceiver, SynchronizationResult}
 import co.ledger.wallet.daemon.utils.HexUtils
 import co.ledger.wallet.daemon.utils.Utils.{RichBigInt, RichCoreBigInt}
+import co.ledger.wallet.daemon.configurations.DaemonConfiguration
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.common.primitives.UnsignedInteger
 import com.twitter.inject.Logging
@@ -344,7 +345,7 @@ object Account extends Logging {
         } yield {
           a.asEthereumLikeAccount()
             .buildTransaction()
-            .setGasLimit(c.convertAmount(gasLimit))
+            .setGasLimit(c.convertAmount((BigDecimal(gasLimit) * BigDecimal(DaemonConfiguration.ETH_SMART_CONTRACT_GAS_LIMIT_FACTOR)).setScale(0, BigDecimal.RoundingMode.CEILING).toBigInt()))
             .sendToAddress(c.convertAmount(0), contract)
             .setInputData(inputData)
         }


### PR DESCRIPTION
Expose ETH_SMART_CONTRACT_GAS_LIMIT_FACTOR for custom gaslimit factor policy on smart contracts
By default this factor is equal to 2 as requested.

see : https://ledgerhq.atlassian.net/browse/BACK-831
And https://ledgerhq.atlassian.net/browse/LV-2481

For more details.

This is globally a workaround for rounded gaslimit on the estimate_gas chain (explorer are suspected)