### PR TITLE
BACK-831: Fix regression due to doubling of gas limit

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -28,6 +28,7 @@ import com.twitter.inject.Logging
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.math.BigDecimal
 
 object Account extends Logging {
 
@@ -337,15 +338,20 @@ object Account extends Logging {
             case _: InvalidEIP55FormatException => Future.failed(InvalidEIP55Format(ti.recipient))
             case _: NotEnoughFundsException => Future.failed(ERC20BalanceNotEnough(contract, 0, ti.amount))
           }
+
           gasLimit <- ti.gasLimit match {
             case Some(amount) => Future.successful(amount)
             case None => ClientFactory.apiClient.getGasLimit(
-              c, ti.contract.getOrElse(ti.recipient), Some(erc20Account.getAddress), Some(inputData))
+                c, ti.contract.getOrElse(ti.recipient), Some(erc20Account.getAddress), Some(inputData)
+            ).map {
+              v => (BigDecimal(v) * BigDecimal(DaemonConfiguration.ETH_SMART_CONTRACT_GAS_LIMIT_FACTOR))
+                .setScale(0, BigDecimal.RoundingMode.CEILING).toBigInt()
+            }
           }
         } yield {
           a.asEthereumLikeAccount()
             .buildTransaction()
-            .setGasLimit(c.convertAmount((BigDecimal(gasLimit) * BigDecimal(DaemonConfiguration.ETH_SMART_CONTRACT_GAS_LIMIT_FACTOR)).setScale(0, BigDecimal.RoundingMode.CEILING).toBigInt()))
+            .setGasLimit(c.convertAmount(gasLimit))
             .sendToAddress(c.convertAmount(0), contract)
             .setInputData(inputData)
         }


### PR DESCRIPTION
There are two situations when a raw transaction is built by the wallet daemon:
1. Computing fees.
2. Building the actual transaction to sign.

Recently, #272 (JIRA: BACK-831) was introduced to double the gas limit estimates provided by the explorers. However, this doubling should only be done when the Gate has not specified the precise gas limit to be used for transaction creation, otherwise, the gas limit will be quadrupled instead of doubled.