### PR TITLE
BACK-1079 AccountSynchronizer becomes an Actor

### DIFF
--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -305,3 +305,14 @@ native_segwit_currencies = ["bitcoin", "bitcoin_testnet", "litecoin", "qtum"]
 # if not specified, will use a dummy publisher
 # rabbitmq.uri = ${RABBITMQ_URI}
 rabbitmq.uri = "amqp://guest:guest@localhost:5672"
+
+akka {
+    wd-blocking-dispatcher {
+      type = Dispatcher
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        fixed-pool-size = 16
+      }
+      throughput = 1
+    }
+}

--- a/src/it/scala/co/ledger/wallet/daemon/services/AccountSynchronizerManagerTest.scala
+++ b/src/it/scala/co/ledger/wallet/daemon/services/AccountSynchronizerManagerTest.scala
@@ -1,6 +1,7 @@
 package co.ledger.wallet.daemon.services
 
-import co.ledger.wallet.daemon.modules.PublisherModule.OperationsPublisherFactory
+import akka.actor.ActorRef
+import co.ledger.wallet.daemon.services.AccountSyncModule.AccountSynchronizerFactory
 import com.twitter.util.{Duration, Time, Timer, TimerTask}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
@@ -28,7 +29,7 @@ class AccountSynchronizerManagerTest extends FlatSpec with MockitoSugar with Def
       override def stop(): Unit = ()
     }
 
-    val manager = new AccountSynchronizerManager(defaultDaemonCache, { (_, _, _, _) => mock[AccountSynchronizer] }, mock[OperationsPublisherFactory], scheduler)
+    val manager = new AccountSynchronizerManager(defaultDaemonCache, mock[AccountSynchronizerFactory], scheduler)
 
     manager.start().futureValue
 
@@ -42,9 +43,9 @@ class AccountSynchronizerManagerTest extends FlatSpec with MockitoSugar with Def
 
     var numberOfSynchronizerCreated = 0
 
-    new AccountSynchronizerManager(defaultDaemonCache, { (_, _, _, _) =>
+    new AccountSynchronizerManager(defaultDaemonCache, { (_, _, _) =>
       numberOfSynchronizerCreated += 1
-      mock[AccountSynchronizer] }, mock[OperationsPublisherFactory], mock[Timer]).start().futureValue
+      mock[ActorRef] }, mock[Timer]).start().futureValue
 
     numberOfSynchronizerCreated should be >= 1
   }

--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -58,16 +58,15 @@ realtimeobservation = true
 # Configuration for Account Synchronizer Manager (ASM)
 synchronization = {
 
-  # check every n seconds to register new account to ASM. default 600
+  # check every n seconds to register new account to ASM
+  sync_account_register_interval_in_seconds = 3
   sync_account_register_interval_in_seconds = ${?SYNC_ACCOUNT_REGISTER_INTERVAL_IN_SECONDS}
 
-  # check every n seconds to update sync status. default 3
-  sync_status_check_interval_in_seconds = ${?SYNC_STATUS_CHECK_INTERVAL_IN_SECONDS}
-
-  # resync request are queued. check the queue every n seconds to launch
-  # account resync. default 3
-  resync_check_interval_in_seconds = ${?RESYNC_CHECK_INTERVAL_IN_SECONDS}
+  # delay between two synchronization
+  sync_interval_in_seconds = 60
+  sync_interval_in_seconds = ${?SYNC_INTERVAL_IN_SECONDS}
 }
+
 
 demo_users = [
   {
@@ -341,3 +340,14 @@ native_segwit_currencies = ["bitcoin", "bitcoin_testnet", "litecoin", "qtum"]
 
 # rabbitMQ uri in the format of 'amqp://user:pass@host:port'
 rabbitmq.uri = ${RABBITMQ_URI}
+
+akka {
+    wd-blocking-dispatcher {
+      type = Dispatcher
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        fixed-pool-size = 16
+      }
+      throughput = 1
+    }
+}

--- a/src/main/scala/co/ledger/wallet/daemon/modules/PublisherModule.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/modules/PublisherModule.scala
@@ -1,6 +1,6 @@
 package co.ledger.wallet.daemon.modules
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorRefFactory, ActorSystem}
 import co.ledger.core.{Account, Wallet}
 import co.ledger.wallet.daemon.configurations.DaemonConfiguration
 import co.ledger.wallet.daemon.services.AccountOperationsPublisher.PoolName
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 import scala.util.{Failure, Success}
 
 object PublisherModule extends TwitterModule with Logging {
-  type OperationsPublisherFactory = (Account, Wallet, PoolName) => ActorRef
+  type OperationsPublisherFactory = (ActorRefFactory, Account, Wallet, PoolName) => ActorRef
 
   @Singleton
   @Provides
@@ -34,8 +34,8 @@ object PublisherModule extends TwitterModule with Logging {
 
   @Provides
   @Singleton
-  def provides(publishersManager: ActorSystem, publisher: Publisher): OperationsPublisherFactory = { (a, w, pn) =>
-    publishersManager.actorOf(AccountOperationsPublisher.props(a, w, pn, publisher))
+  def provides(publisher: Publisher): OperationsPublisherFactory = { (factory, a, w, pn) =>
+    factory.actorOf(AccountOperationsPublisher.props(a, w, pn, publisher))
   }
 
 }

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -269,6 +269,7 @@ class AccountsService @Inject()(daemonCache: DaemonCache, synchronizerManager: A
         w.addAccountIfNotExist(accountCreationBody).flatMap { a =>
           val accountInfo = AccountInfo(a.getIndex, walletInfo)
           synchronizerManager.registerAccount(a, w, accountInfo)
+
           val syncStatus = synchronizerManager.getSyncStatus(accountInfo).get
           a.accountView(walletInfo.walletName, w.getCurrency.currencyView, syncStatus)
         }


### PR DESCRIPTION
The AccountSynchronizer does not block threads anymore. 
It delegates operations publishing to another actor. 
Both AccountSynchronizer and AccountOperationsPublisher share the same wd-blocking dispatcher for libcore jobs.


