### PR TITLE
BACK-1099 upgrade jvm to 8u272 openJ9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### BUILD STEP ###
-FROM openjdk:8u181-jdk-stretch as builder
+FROM adoptopenjdk:8u272-b10-jdk-openj9-0.23.0-focal as builder
 ARG COMMIT_HASH=""
 ENV STAGE dev
 ENV COMMIT_HASH $COMMIT_HASH
@@ -9,7 +9,7 @@ ADD . /build
 RUN ./docker/build.sh
 
 #### RUN STEP ###
-FROM openjdk:8u181-jre-slim-stretch
+FROM adoptopenjdk:8u272-b10-jre-openj9-0.23.0
 ENV HTTP_PORT 9200
 ENV ADMIN_PORT 0
 ENV STAGE dev


### PR DESCRIPTION
Giving a try to openJ9 JVM on JNI objects garbage collecting.
With hotspot, a memory leak has been observed leading to WD crash.