### PR TITLE
Fix: retain synchronization event bus

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -110,7 +110,7 @@ object Account extends Logging {
 
     def operationViewsFromHeight(offset: Int, batch: Int, fullOp: Int, fromHeight: Long, w: Wallet)(implicit ec: ExecutionContext): Future[Seq[OperationView]] = {
       val opQuery: OperationQuery = a.queryOperations()
-      opQuery.filter().opAnd(QueryFilter.blockHeightGt(fromHeight))
+      opQuery.filter().opAnd(QueryFilter.blockHeightGt(fromHeight).opOr(QueryFilter.blockHeightIsNull()))
       Account.operationViews(offset, batch, fullOp, opQuery, w, a)
     }
 

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -534,10 +534,11 @@ object Account extends Logging {
   def sync(poolName: String, walletName: String, a: core.Account)(implicit ec: ExecutionContext): Future[SynchronizationResult] = {
     val promise: Promise[SynchronizationResult] = Promise[SynchronizationResult]()
     val receiver: core.EventReceiver = new SynchronizationEventReceiver(a.getIndex, walletName, poolName, promise)
-    a.synchronize().subscribe(LedgerCoreExecutionContext(ec), receiver)
+    val synchronizationBus = a.synchronize()
+    synchronizationBus.subscribe(LedgerCoreExecutionContext(ec), receiver)
     debug(s"Synchronize $a")
     val f = promise.future
-    f onComplete (_ => a.getEventBus.unsubscribe(receiver))
+    f onComplete (_ => synchronizationBus.unsubscribe(receiver))
     f
   }
 

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountOperationsPublisher.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountOperationsPublisher.scala
@@ -40,7 +40,10 @@ class AccountOperationsPublisher(account: Account, wallet: Wallet, poolName: Poo
   override def receive: Receive = LoggingReceive {
     case SubscribeToOperationsCount(subscriber) => operationsCountSubscribers.add(subscriber)
 
-    case s: SyncStatus if account.isInstanceOfEthereumLikeAccount => publisher.publishERC20Accounts(account, wallet, poolName.name, s)
+    case s: SyncStatus if account.isInstanceOfEthereumLikeAccount =>
+      publisher.publishAccount(account, wallet, poolName.name, s).flatMap(_ => {
+        publisher.publishERC20Accounts(account, wallet, poolName.name, s)
+      })
     case s: SyncStatus => publisher.publishAccount(account, wallet, poolName.name, s)
 
     case NewOperationEvent(opId) if account.isInstanceOfEthereumLikeAccount =>


### PR DESCRIPTION
Current implementation register a receiver on one event bus and unregister it on another.
This PR retains the synchronization event bus until the synchronization is over. Otherwise the daemon never gets notified of new synchronization events.

This PR also publishes account state for ETH accounts.

This PR also publishes unconfirmed (mempool) transaction when the "repush" endpoint is called.