### PR TITLE
Add retry mechanism on http client given to ledger core

### DIFF
--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -10,6 +10,12 @@ sqlite3 = {
   connectionPool = disabled
 }
 
+core = {
+  ops_threads_factor = 4
+  ops_threads_factor = ${?CORE_OPS_THREADS_FACTOR}
+  http_client_retries = 10
+  http_client_retries = ${?CORE_HTTP_RETRIES}
+}
 
 postgres = {
   host = "localhost"

--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -190,6 +190,19 @@ explorer = {
         disable_sync_token = ${?ETH_ROPSTEN_DISABLE_SYNC_TOKEN}
       }
       {
+        currency = litecoin
+        host = "https://api.ledgerwallet.com"
+        host = ${?WALLET_LTC_EXPLORER_ENDPOINT}
+        port = 443
+        port = ${?WALLET_LTC_EXPLORER_PORT}
+        explorer_version = "v2"
+        explorer_version = ${?WALLET_LTC_EXPLORER_VERSION}
+        proxyuse = true
+        proxyuse = ${?WALLET_LTC_EXPLORER_PROXYUSE}
+        disable_sync_token = false
+        disable_sync_token = ${?LTC_DISABLE_SYNC_TOKEN}
+      }
+      {
         currency = ripple
         host = "https://s2.ripple.com"
         host = ${?WALLET_XRP_EXPLORER_ENDPOINT}

--- a/src/main/resources/application.conf.sample
+++ b/src/main/resources/application.conf.sample
@@ -6,6 +6,8 @@ core_database_engine = ${?CORE_DATABASE_ENGINE}
 core = {
   ops_threads_factor = 4
   ops_threads_factor = ${?CORE_OPS_THREADS_FACTOR}
+  http_client_retries = 10
+  http_client_retries = ${?CORE_HTTP_RETRIES}
 }
 
 sqlite3 = {
@@ -191,15 +193,15 @@ explorer = {
       }
       {
         currency = litecoin
-        host = "https://api.ledgerwallet.com"
+        host = "https://explorers.api.vault.ledger.com"
         host = ${?WALLET_LTC_EXPLORER_ENDPOINT}
         port = 443
         port = ${?WALLET_LTC_EXPLORER_PORT}
-        explorer_version = "v2"
+        explorer_version = "v3"
         explorer_version = ${?WALLET_LTC_EXPLORER_VERSION}
         proxyuse = true
         proxyuse = ${?WALLET_LTC_EXPLORER_PROXYUSE}
-        disable_sync_token = false
+        disable_sync_token = true
         disable_sync_token = ${?LTC_DISABLE_SYNC_TOKEN}
       }
       {

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ClientFactory.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ClientFactory.scala
@@ -3,12 +3,15 @@ package co.ledger.wallet.daemon.clients
 import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 
 import co.ledger.wallet.daemon.libledger_core.async.{LedgerCoreExecutionContext, ScalaThreadDispatcher}
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.ExecutionContext
 
 object ClientFactory {
+  private val config = ConfigFactory.load()
+
   lazy val webSocketClient = new ScalaWebSocketClient
-  lazy val httpCoreClient = new HttpCoreClientPool(LedgerCoreExecutionContext.httpPool, new ScalaHttpClientPool)
+  lazy val httpCoreClient = new HttpCoreClientPool(LedgerCoreExecutionContext.httpPool, new ScalaHttpClientPool, config.getInt("core.http_client_retries"))
 
   lazy val threadDispatcher = new ScalaThreadDispatcher(
     ExecutionContext.fromExecutor(new ThreadPoolExecutor(Runtime.getRuntime.availableProcessors() * 4, Runtime.getRuntime.availableProcessors() * 8, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable], (r: Runnable) => new Thread(r, "libcore-thread-dispatcher")))


### PR DESCRIPTION
Add a auto-retry mechanism on HTTP client to retry all calls which returns an error 5XX. The numbers of retry can be changed by using the env variable CORE_HTTP_RETRIES