### PR TITLE
BACK-1320 : Log verbosity reduction

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -28,14 +28,14 @@
             <pattern>%date %thread TraceId=%X{traceId} CorrelationId=%X{correlationId} [%level] %logger{0} : %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="co.ledger.wallet.daemon.libledger_core" level="debug" />
-    <logger name="co.ledger.wallet.daemon" level="debug" />
+    <logger name="co.ledger.wallet.daemon.libledger_core" level="error" />
+    <logger name="co.ledger.wallet.daemon" level="info" />
     <logger name="slick" level="warn" />
     <logger name="io.netty" level="warn" />
     <logger name="com.twitter" level="warn" />
     <logger name="com.twitter.finatra.http.filters.AccessLoggingFilter" level="info" />
     <logger name="djinni" level="warn" />
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/main/scala/co/ledger/wallet/daemon/clients/HttpCoreClientPool.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/HttpCoreClientPool.scala
@@ -46,9 +46,6 @@ class HttpCoreClientPool(val ec: ExecutionContext, client: ScalaHttpClientPool, 
       endpoint <- getEndpoint(httpCoreRequest)
       request <- newRequest(httpCoreRequest, endpoint)
       response <- client.execute(endpoint.host, request).asScala()
-      _ = info(s"Core Http received from ${httpCoreRequest.getUrl} status=${response.status.code} " +
-               s"error=${isOnError(response.status.code)} " +
-               s"- statusText=${response.status.reason}")
       connection = httpResponseToConnection(response)
     } yield connection
   }

--- a/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClientPool.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/clients/ScalaHttpClientPool.scala
@@ -43,9 +43,9 @@ class ScalaHttpClientPool extends Logging {
   def execute(host: Host, request: Request): com.twitter.util.Future[Response] =
     serviceForHost(host)(request).map(response => {
       info(s"Received from ${request.host.getOrElse("No host")} - ${request.uri} status=${response.status.code} " +
-        s"error=${isOnError(response.status.code)} - statusText=${response.status.reason} - " +
-        s"Request : $request - (Payload : ${Utils.preview(request.getContentString(), 200)}) - " +
-        s"Response : $response - (Payload : ${Utils.preview(response.getContentString(), 200)})")
+        s"success=${!isOnError(response.status.code)} - statusText=${response.status.reason} - " +
+        s"Request : $request - (Payload : ${Utils.preview(request.getContentString(), 400)}) - " +
+        s"Response : $response - (Payload : ${Utils.preview(response.getContentString(), 400)})")
       response
     }).onFailure(th => error(s"Failed to execute request on host $host with request $request. Error message : ${th.getMessage}", th))
 }

--- a/src/main/scala/co/ledger/wallet/daemon/libledger_core/logger/NoOpLogPrinter.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/libledger_core/logger/NoOpLogPrinter.scala
@@ -1,4 +1,4 @@
-package co.ledger.wallet.daemon.libledger_core.debug
+package co.ledger.wallet.daemon.libledger_core.logger
 
 import co.ledger.core.{ExecutionContext, LogPrinter}
 import com.twitter.inject.Logging

--- a/src/main/scala/co/ledger/wallet/daemon/models/Pool.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Pool.scala
@@ -12,7 +12,7 @@ import co.ledger.wallet.daemon.database.{PoolDto, PostgresPreferenceBackend}
 import co.ledger.wallet.daemon.exceptions.{CoreDatabaseException, CurrencyNotFoundException, UnsupportedNativeSegwitException, WalletNotFoundException}
 import co.ledger.wallet.daemon.libledger_core.async.LedgerCoreExecutionContext
 import co.ledger.wallet.daemon.libledger_core.crypto.SecureRandomRNG
-import co.ledger.wallet.daemon.libledger_core.debug.NoOpLogPrinter
+import co.ledger.wallet.daemon.libledger_core.logger.NoOpLogPrinter
 import co.ledger.wallet.daemon.libledger_core.filesystem.ScalaPathResolver
 import co.ledger.wallet.daemon.models.Wallet._
 import co.ledger.wallet.daemon.schedulers.observers.SynchronizationResult


### PR DESCRIPTION
* Global wallet daemon logger level is info for production
* Do not duplicate http client log when receive explorer response
* Enhance request and response logging from 200 to 400 char truncated
* Libcore is now logging at **error** level for production