### PR TITLE
Fix ERC20 publish message format

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountOperationsPublisher.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountOperationsPublisher.scala
@@ -44,7 +44,7 @@ class AccountOperationsPublisher(daemonCache: DaemonCache, account: Account, wal
   override def receive: Receive = LoggingReceive {
     case s: SyncStatus if account.isInstanceOfEthereumLikeAccount =>
       publisher.publishAccount(pool, account, wallet, s).flatMap(_ => {
-        publisher.publishERC20Accounts(account, wallet, poolName.name, s)
+        publisher.publishERC20Accounts(pool, account, wallet, s)
       })
     case s: SyncStatus =>
       publisher.publishAccount(pool, account, wallet, s)


### PR DESCRIPTION
Adds:
- token family
- token name
- change publishERC20Account base method to take whole Pool instead of just poolName