### PR TITLE
[BACK-1565] Add implementation of fetching ERC20 operations from last block height

### DIFF
--- a/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
@@ -67,6 +67,12 @@ class WalletPoolDao(poolName: String)(implicit val ec: ExecutionContext) extends
   override def findERC20OperationsByUids(a: Account, w: Wallet, filteredUids: Seq[ERC20OperationUid], offset: Int, limit: Int): Future[Seq[OperationView]] =
     erc20daoForWalletType(w.getWalletType: WalletType).findERC20OperationsByUids(a, w, filteredUids, offset, limit)
 
+  /**
+    * List erc20 operations from an account starting at specified bock height
+    */
+  override def findERC20OperationsFromBlockHeight(a: Account, w: Wallet, blockHeight: Long, offset: Int, limit: Int): Future[Seq[OperationView]] =
+    erc20daoForWalletType(w.getWalletType: WalletType).findERC20OperationsFromBlockHeight(a, w, blockHeight, offset, limit)
+
 }
 
 object WalletPoolDao {

--- a/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
@@ -68,7 +68,7 @@ class WalletPoolDao(poolName: String)(implicit val ec: ExecutionContext) extends
     erc20daoForWalletType(w.getWalletType: WalletType).findERC20OperationsByUids(a, w, filteredUids, offset, limit)
 
   /**
-    * List erc20 operations from an account starting at specified bock height
+    * List erc20 operations from an account starting at specified block height
     */
   override def findERC20OperationsFromBlockHeight(a: Account, w: Wallet, blockHeight: Long, offset: Int, limit: Int): Future[Seq[OperationView]] =
     erc20daoForWalletType(w.getWalletType: WalletType).findERC20OperationsFromBlockHeight(a, w, blockHeight, offset, limit)

--- a/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/WalletPoolDao.scala
@@ -13,7 +13,7 @@ class WalletPoolDao(poolName: String)(implicit val ec: ExecutionContext) extends
   val db: Database = new Database(DaemonConfiguration.coreDbConfig, poolName)
 
   lazy val btcDao = new BitcoinDao(db)
-  lazy val ethDao = new EthereumDao(db)
+  lazy val ethDao = new EthereumDao(db, poolName)
   lazy val xrpDao = new RippleDao(db)
   lazy val xlmDao = new StellarDao(db)
 

--- a/src/main/scala/co/ledger/wallet/daemon/database/core/operations/ERC20Dao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/operations/ERC20Dao.scala
@@ -24,4 +24,8 @@ trait ERC20Dao {
     */
   def findERC20OperationsByUids(a: Account, w: Wallet, filteredUids: Seq[ERC20OperationUid], offset: Int, limit: Int): Future[Seq[OperationView]]
 
+  /**
+    * List erc20 operations from an account starting at specified bock height
+    */
+  def findERC20OperationsFromBlockHeight(a: Account, w: Wallet, blockHeight: Long, offset: Int, limit: Int): Future[Seq[OperationView]]
 }

--- a/src/main/scala/co/ledger/wallet/daemon/database/core/operations/ERC20Dao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/operations/ERC20Dao.scala
@@ -25,7 +25,7 @@ trait ERC20Dao {
   def findERC20OperationsByUids(a: Account, w: Wallet, filteredUids: Seq[ERC20OperationUid], offset: Int, limit: Int): Future[Seq[OperationView]]
 
   /**
-    * List erc20 operations from an account starting at specified bock height
+    * List erc20 operations from an account starting at specified block height
     */
   def findERC20OperationsFromBlockHeight(a: Account, w: Wallet, blockHeight: Long, offset: Int, limit: Int): Future[Seq[OperationView]]
 }

--- a/src/main/scala/co/ledger/wallet/daemon/database/core/operations/EthereumDao.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/database/core/operations/EthereumDao.scala
@@ -38,8 +38,8 @@ class EthereumDao(protected val db: Database, protected val poolName: String) ex
         "ORDER BY ercop.date " + order.value +
         s" OFFSET $offset LIMIT $limit"
 
-  private val erc20OperationFromBlockHeightQuery: (Int, String, Ordering.OperationOrder, Long, Int, Int) => SQLQuery =
-    (accountIndex: Int, walletName: String, order: Ordering.OperationOrder, blockHeight: Long, offset: Int, limit: Int) =>
+  private val erc20OperationFromBlockHeightQuery: (Int, String, Long, Int, Int) => SQLQuery =
+    (accountIndex: Int, walletName: String, blockHeight: Long, offset: Int, limit: Int) =>
       s"""
         |SELECT ercop.uid as erc_uid, ercop.ethereum_operation_uid as eth_uid, ercop.receiver, ercop.value
         | FROM wallets w, erc20_operations ercop, erc20_accounts ercacc, ethereum_accounts ethacc
@@ -249,7 +249,7 @@ class EthereumDao(protected val db: Database, protected val poolName: String) ex
   }
 
   private def queryERC20OperationsFromBlockHeightFullView(a: Account, w: Wallet, blockHeight: Long, offset: Int, limit: Int)(f: Row => OperationView): Future[Seq[OperationView]] = {
-    db.executeQuery(erc20OperationFromBlockHeightQuery(a.getIndex, w.getName, Ordering.Ascending, blockHeight, offset, limit))(f)
+    db.executeQuery(erc20OperationFromBlockHeightQuery(a.getIndex, w.getName, blockHeight, offset, limit))(f)
   }
 
   private def rowToFullOperationView(w: Wallet, accountIndex: Int)(row: Row) = {

--- a/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/models/Account.scala
@@ -116,6 +116,9 @@ object Account extends Logging {
       Account.operationViews(offset, batch, fullOp, opQuery, w, a)
     }
 
+    def erc20OperationsFromHeight(pool: Pool, wallet: Wallet, account: Account, offset: Int, batch: Int, fromHeight: Long): Future[Seq[OperationView]] =
+      pool.walletPoolDao.findERC20OperationsFromBlockHeight(account, wallet, fromHeight, offset, batch).asScala()
+
     def freshAddresses(implicit ec: ExecutionContext): Future[Seq[core.Address]] =
       Account.freshAddresses(a)
 

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -292,7 +292,7 @@ class AccountsService @Inject()(daemonCache: DaemonCache, synchronizerManager: A
           ))
         val pushErc20Future: Future[Unit] = if (account.isInstanceOfEthereumLikeAccount) {
           daemonCache.withAccountAndWalletAndPool(accountInfo) { (account, wallet, pool) =>
-            account.erc20OperationsFromHeight(pool, wallet, account, 0, Int.MaxValue, fromHeight.getOrElse(0)).map(_.map(view =>
+            account.erc20OperationsFromHeight(pool, wallet, account, offset = 0, batch = Int.MaxValue, fromHeight.getOrElse(0)).map(_.map(view =>
               publisher.publishERC20Operation(view, account, wallet, accountInfo.poolName)
             ))
           }

--- a/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
+++ b/src/main/scala/co/ledger/wallet/daemon/services/AccountsService.scala
@@ -291,9 +291,11 @@ class AccountsService @Inject()(daemonCache: DaemonCache, synchronizerManager: A
             publisher.publishOperation(view, account, wallet, accountInfo.poolName)
           ))
         val pushErc20Future: Future[Unit] = if (account.isInstanceOfEthereumLikeAccount) {
-          account.erc20Operations(wallet).map(_.map(view =>
-            publisher.publishERC20Operation(view, account, wallet, accountInfo.poolName)
-          ))
+          daemonCache.withAccountAndWalletAndPool(accountInfo) { (account, wallet, pool) =>
+            account.erc20OperationsFromHeight(pool, wallet, account, 0, Int.MaxValue, fromHeight.getOrElse(0)).map(_.map(view =>
+              publisher.publishERC20Operation(view, account, wallet, accountInfo.poolName)
+            ))
+          }
         } else Future.unit
         pushOperationFuture.flatMap(_ => pushErc20Future)
     }


### PR DESCRIPTION
This PR solves BACK-1565 wheer every single operations were pushed instead of all operations from the given block height.

It does so through the usage of WalletPoolDao, to continue the replacement of going through Libcore's dedicated system.